### PR TITLE
fix: better caption size on larger screens

### DIFF
--- a/src/components/VideoDialog.vue
+++ b/src/components/VideoDialog.vue
@@ -368,6 +368,7 @@ export default class VideoDialog extends Vue {
 
 .plyr {
   height: 100%;
+  --plyr-font-size-xlarge: 40px;
 }
 
 .plyr__poster {


### PR DESCRIPTION
Default large caption size is 21px. This is too small when watching fullscreen on a laptop. Especially when connected to a TV via HDMI.