### PR TITLE
fix(App): scroll within main content

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -188,3 +188,21 @@ export default class App extends Vue {
   }
 }
 </script>
+<style lang="scss">
+* {
+  scrollbar-width: thin;
+}
+
+html {
+  overflow-y: hidden;
+}
+
+.v-main {
+  height: 100dvh;
+}
+
+.v-main__wrap {
+  overflow-y: auto;
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
Currently, the scrollbar starts behind the fixed toolbar. This looks a bit weird and makes the scrollbar height somewhat misleading. With this fix, the scrollbar starts below the fixed toolbar and only scrolls within the main content. 

Besides that, I also added the `scrollbar-width: thin` to make the scrollbar a little nicer to look at.