### PR TITLE
fix(dialog): prevent grid flicker when opening video dialog

### DIFF
--- a/components/VideoGrid.vue
+++ b/components/VideoGrid.vue
@@ -19,12 +19,9 @@ import type { Video } from '~/types';
 defineProps<{ videos: Video[] }>();
 
 const store = useAppStore();
-const route = useRoute();
-const router = useRouter();
 
 function onClickVideo(video: Video) {
   store.setSelectedVideo(video);
   store.setVideoDialog(true);
-  router.push(`/${route.params.language}/${video.languageAgnosticNaturalKey}`);
 }
 </script>

--- a/components/VideoSwiper.vue
+++ b/components/VideoSwiper.vue
@@ -34,8 +34,6 @@ import type { Video } from '~/types';
 defineProps<{ videos: Video[] }>();
 
 const store = useAppStore();
-const route = useRoute();
-const router = useRouter();
 const { mdAndUp } = useDisplay();
 
 const modules = [Navigation, Scrollbar, FreeMode];
@@ -43,7 +41,6 @@ const modules = [Navigation, Scrollbar, FreeMode];
 function onClickVideo(video: Video) {
   store.setSelectedVideo(video);
   store.setVideoDialog(true);
-  router.push(`/${route.params.language}/${video.languageAgnosticNaturalKey}`);
 }
 </script>
 

--- a/pages/[language]/[[videoId]].vue
+++ b/pages/[language]/[[videoId]].vue
@@ -40,6 +40,13 @@
 import axios from 'axios';
 import type { Language, Translations, Video } from '~/types';
 
+definePageMeta({
+  // Keep the same component instance when only videoId changes (e.g. opening/closing a video
+  // dialog). Without this, Nuxt generates different page keys for /:language and
+  // /:language/:videoId, causing a full remount and visible grid flicker on every dialog open.
+  key: (route) => route.params.language as string,
+});
+
 const store = useAppStore();
 const route = useRoute();
 const router = useRouter();


### PR DESCRIPTION
Nuxt's NuxtPage generates different component keys for /:language and /:language/:videoId (e.g. "/nl()/" vs "/nl()/lank"), causing the entire page component to unmount and remount on every dialog open/close. This destroyed the VideoCategory state, blanking all grids until API responses returned.

Fix by pinning the page key to the language param only via definePageMeta, so adding/removing videoId in the URL reuses the same component instance.

Also remove the redundant router.push from VideoGrid and VideoSwiper — the VideoDialog watcher already handles URL updates when videoDialog opens, so both were pushing the same navigation simultaneously.

https://claude.ai/code/session_014SAmeMtT5rYfaGo6vbff6J