### PR TITLE
fix(cast): resolve race condition where Cast SDK loads before Vue mounts

### DIFF
--- a/composables/useCast.ts
+++ b/composables/useCast.ts
@@ -11,6 +11,7 @@
 // Cast SDK types (minimal, avoids a large @types package)
 interface CastWindow {
   __onGCastApiAvailable?: (isAvailable: boolean) => void;
+  __castApiReady?: boolean;
   cast?: {
     framework: {
       CastContext: {
@@ -25,7 +26,6 @@ interface CastWindow {
   chrome?: {
     cast: {
       media: {
-        DEFAULT_MEDIA_RECEIVER_APP_ID: string;
         MediaInfo: new (url: string, contentType: string) => MediaInfo;
         LoadRequest: new (mediaInfo: MediaInfo) => LoadRequest;
         Track: new (id: number, type: string) => MediaTrack;
@@ -74,16 +74,32 @@ const isAvailable = ref(false);
 export function useCast() {
   function initCast() {
     if (typeof window === 'undefined') return;
+    const w = window as unknown as CastWindow;
 
-    (window as unknown as CastWindow).__onGCastApiAvailable = (available: boolean) => {
-      if (!available) return;
-      const w = window as unknown as CastWindow;
-      w.cast?.framework.CastContext.getInstance().setOptions({
-        receiverApplicationId: w.chrome?.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID,
-        autoJoinPolicy: w.chrome?.cast.AutoJoinPolicy.ORIGIN_SCOPED,
-      });
-      isAvailable.value = true;
+    const configureCast = () => {
+      if (isAvailable.value) return;
+      try {
+        w.cast!.framework.CastContext.getInstance().setOptions({
+          receiverApplicationId: 'CC1AD845',
+          autoJoinPolicy: w.chrome!.cast.AutoJoinPolicy.ORIGIN_SCOPED,
+        });
+        isAvailable.value = true;
+      } catch {
+        // Cast API present but configuration failed
+      }
     };
+
+    // Register callback for when the SDK loads (replaces the early inline stub)
+    w.__onGCastApiAvailable = (available: boolean) => {
+      if (!available) return;
+      configureCast();
+    };
+
+    // Handle race condition: SDK may have already loaded and called the
+    // early inline __onGCastApiAvailable before Vue mounted
+    if (w.__castApiReady && w.cast?.framework && w.chrome?.cast) {
+      configureCast();
+    }
   }
 
   /**

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,6 +54,10 @@ export default defineNuxtConfig({
           async: true,
         },
         {
+          // Early Cast callback — captures SDK readiness before Vue mounts
+          innerHTML: `window.__onGCastApiAvailable=function(a){window.__castApiReady=a;};`,
+        },
+        {
           // Google Cast Sender SDK — calls window.__onGCastApiAvailable when ready
           src: 'https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1',
           async: true,


### PR DESCRIPTION
The __onGCastApiAvailable callback was only registered in onMounted, but the async Cast SDK script could fire it earlier. Added an early inline callback stub in the HTML head to capture readiness, and initCast() now checks if the API is already available when it runs.

https://claude.ai/code/session_0169qaPQaew642rRBsp2LBTw