### PR TITLE
fix(player): drop volume slider on mobile so the seek bar has room

### DIFF
--- a/app/composables/usePlyrPlayer.ts
+++ b/app/composables/usePlyrPlayer.ts
@@ -114,6 +114,14 @@ export function usePlyrPlayer(
     }
 
     player = new Plyr(playerEl.value, {
+      // Plyr's default control bar minus the volume slider on mobile: it crowds
+      // out the flex-growing progress bar on narrow portrait viewports. The mute
+      // toggle stays; hardware volume keys handle levels there.
+      controls: [
+        'play-large', 'play', 'progress', 'current-time', 'mute',
+        ...(smAndDown.value ? [] : ['volume']),
+        'captions', 'settings', 'pip', 'airplay', 'fullscreen',
+      ],
       quality: { default: 1080, options: [1080, 720, 480, 360, 240] },
       captions: { active: true, language: languageStore.subtitleLanguageInfo.locale, update: true },
       // Few enough options that the settings menu can't soft-lock


### PR DESCRIPTION
Plyr received no controls option, so it used its default single-row bar where the fixed-width volume slider crowds out the flex-growing progress bar on narrow portrait viewports, leaving the seek bar unusably tiny. Pass an explicit controls array that omits `volume` on smAndDown (keeping the mute toggle); desktop keeps Plyr's default bar unchanged.


Claude-Session: https://claude.ai/code/session_01M21nLP7Zy7Y4f7S9gk372k