### PR TITLE
feat(transcript): full-screen expand toggle on mobile

### DIFF
--- a/app/components/player/TranscriptPanel.vue
+++ b/app/components/player/TranscriptPanel.vue
@@ -19,6 +19,18 @@
       </v-btn>
 
       <v-btn
+        v-if="expandable"
+        density="comfortable"
+        icon
+        variant="text"
+        @click="onToggleExpand"
+      >
+        <v-icon>
+          {{ uiStore.transcriptExpanded ? 'mdi-arrow-collapse-down' : 'mdi-arrow-expand-up' }}
+        </v-icon>
+      </v-btn>
+
+      <v-btn
         v-if="closable"
         density="comfortable"
         icon
@@ -103,6 +115,7 @@ const props = defineProps<{
   vttUrl: string | null;
   currentTime: number;
   closable?: boolean;
+  expandable?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -200,6 +213,12 @@ function updateActiveAbove() {
 function onResume() {
   userScrolled.value = false;
   scrollToActive();
+}
+
+function onToggleExpand() {
+  uiStore.setTranscriptExpanded(!uiStore.transcriptExpanded);
+  userScrolled.value = false;
+  nextTick(() => scrollToActive('instant'));
 }
 
 function onClickCue(cue: SubtitleCue) {

--- a/app/components/player/VideoDialog.vue
+++ b/app/components/player/VideoDialog.vue
@@ -33,7 +33,13 @@
 
       <!-- Player -->
       <template v-else>
-        <div class="player-row" :class="{ 'player-row--split': uiStore.transcriptPanel && !smAndDown }">
+        <div
+          class="player-row"
+          :class="{
+            'player-row--split': uiStore.transcriptPanel && !smAndDown,
+            'player-row--hidden': uiStore.transcriptExpanded && smAndDown,
+          }"
+        >
           <v-responsive :aspect-ratio="16 / 9" class="player-frame">
             <!-- Exclusive playback: while casting, the local player is torn
                  down and replaced by a placeholder; CastBar has the controls -->
@@ -79,6 +85,7 @@
           class="transcript-below"
           closable
           :current-time="transcriptTime"
+          expandable
           :vtt-url="subtitleUrl"
           @seek="onSeekTranscript"
         />
@@ -307,6 +314,9 @@ watch(
 .transcript-below {
   flex-grow: 1;
   min-height: 0;
+}
+.player-row--hidden {
+  display: none;
 }
 .plyr {
   height: 100%;

--- a/app/stores/ui.ts
+++ b/app/stores/ui.ts
@@ -4,6 +4,7 @@ export const useUiStore = defineStore('ui', () => {
   const searchDialog = ref(false);
   const videoDialog = ref(false);
   const transcriptPanel = ref(false);
+  const transcriptExpanded = ref(false);
   const getNotifiedDialog = ref(false);
   const selectedVideo = ref<Video | null>(null);
 
@@ -16,6 +17,12 @@ export const useUiStore = defineStore('ui', () => {
   }
   function setTranscriptPanel(value: boolean) {
     transcriptPanel.value = value;
+    if (!value) {
+      transcriptExpanded.value = false;
+    }
+  }
+  function setTranscriptExpanded(value: boolean) {
+    transcriptExpanded.value = value;
   }
   function setGetNotifiedDialog(value: boolean) {
     getNotifiedDialog.value = value;
@@ -35,11 +42,13 @@ export const useUiStore = defineStore('ui', () => {
     searchDialog,
     videoDialog,
     transcriptPanel,
+    transcriptExpanded,
     getNotifiedDialog,
     selectedVideo,
     setSearchDialog,
     setVideoDialog,
     setTranscriptPanel,
+    setTranscriptExpanded,
     setGetNotifiedDialog,
     setSelectedVideo,
     openVideo,


### PR DESCRIPTION
Add an expand/collapse control to the mobile transcript panel so it can cover the video and fill the screen — useful for reading along while casting, where the video area is only a static placeholder anyway.

- ui store: new transcriptExpanded flag + setter; setTranscriptPanel(false) also clears it so closing the panel can't leave a stale expanded state
- TranscriptPanel: expandable prop renders an arrow toggle in the header (mdi-arrow-expand-up / mdi-arrow-collapse-down); recenters the active cue after toggling
- VideoDialog: pass expandable to the mobile panel; hide .player-row via CSS (display:none, not v-if) when expanded so the local player keeps playing


Claude-Session: https://claude.ai/code/session_01NuQKYXoULBaYcbAxBuHRXy