### PR TITLE
Add mobile rotate-to-fullscreen for video player

### DIFF
--- a/app/composables/usePlyrPlayer.ts
+++ b/app/composables/usePlyrPlayer.ts
@@ -78,6 +78,26 @@ export function usePlyrPlayer(
   onMounted(() => document.addEventListener('keydown', onKeydownCapture, true));
   onBeforeUnmount(() => document.removeEventListener('keydown', onKeydownCapture, true));
 
+  // Mobile rotate-to-fullscreen: entering landscape while playing goes
+  // fullscreen; returning to portrait always leaves it. Desktop and casting
+  // (player is undefined) are excluded by the guards.
+  const landscapeQuery = window.matchMedia('(orientation: landscape)');
+  function onOrientationChange(e: MediaQueryListEvent) {
+    if (!smAndDown.value || !player) {
+      return;
+    }
+    if (e.matches) {
+      if (player.playing) {
+        player.fullscreen.enter();
+      }
+    }
+    else {
+      player.fullscreen.exit();
+    }
+  }
+  onMounted(() => landscapeQuery.addEventListener('change', onOrientationChange));
+  onBeforeUnmount(() => landscapeQuery.removeEventListener('change', onOrientationChange));
+
   async function loadPlayer() {
     if (!playerEl.value || !source.videoMedia.value) {
       return;


### PR DESCRIPTION
## Summary
Adds automatic fullscreen behavior to the Plyr video player on mobile devices when the device is rotated to landscape orientation, with automatic exit when returning to portrait.

## Changes
- Added orientation change listener using `window.matchMedia('(orientation: landscape)')` to detect landscape/portrait transitions
- Implemented `onOrientationChange` handler that:
  - Only activates on small/medium screens (`smAndDown.value`) and when a player instance exists
  - Enters fullscreen automatically when rotating to landscape **if video is currently playing**
  - Always exits fullscreen when returning to portrait
  - Excludes desktop and casting scenarios (where player is undefined)
- Registered listener on component mount and cleanup on unmount, following existing event listener patterns in the file

## Implementation Details
The feature respects the existing player state — fullscreen is only entered on landscape rotation if the video is actively playing (`player.playing`), preventing unwanted fullscreen transitions during paused playback. The guard conditions ensure the feature only applies to mobile devices and active playback scenarios, not desktop or Chromecast casting.

https://claude.ai/code/session_019pjnyntKBRaVsGcLbGFgTi