### PR TITLE
Wrap Plyr video element in Vue-owned div to prevent orphaning

### DIFF
--- a/app/components/player/VideoDialog.vue
+++ b/app/components/player/VideoDialog.vue
@@ -42,16 +42,20 @@
         >
           <v-responsive :aspect-ratio="16 / 9" class="player-frame">
             <!-- Exclusive playback: while casting, the local player is torn
-                 down and replaced by a placeholder; CastBar has the controls -->
-            <video
-              v-if="!castActive"
-              ref="playerEl"
-              class="player-video"
-              controls
-              crossorigin="anonymous"
-              playsinline
-              :poster="videoPoster"
-            />
+                 down and replaced by a placeholder; CastBar has the controls.
+                 Plyr's destroy() swaps the <video> for an internal clone, so
+                 the v-if must sit on a Vue-owned wrapper — never the Plyr
+                 element itself — or the clone orphans on teardown. -->
+            <div v-if="!castActive" class="player-host">
+              <video
+                ref="playerEl"
+                class="player-video"
+                controls
+                crossorigin="anonymous"
+                playsinline
+                :poster="videoPoster"
+              />
+            </div>
 
             <v-img
               v-else
@@ -302,6 +306,9 @@ watch(
 .dialog-title {
   word-break: normal;
   user-select: none;
+}
+.player-host {
+  height: 100%;
 }
 .player-video {
   width: 100%;


### PR DESCRIPTION
## Summary

Fixes a teardown bug where Plyr's `destroy()` method orphans its internal clone when the `<video>` element is directly controlled by a Vue `v-if`. The fix wraps the video element in a Vue-owned container div so that the conditional rendering applies to the wrapper, not the Plyr element itself.

## Changes

- **Wrapped `<video>` in a new `<div class="player-host">`** — The `v-if="!castActive"` now sits on the wrapper div instead of directly on the video element. This ensures Vue owns the entire subtree and can properly clean it up when Plyr replaces the video with an internal clone during `destroy()`.
- **Added `.player-host` CSS rule** — Sets `height: 100%` to maintain the responsive aspect ratio through the wrapper.
- **Updated comment** — Clarified the Plyr teardown behavior and why the v-if must sit on a Vue-owned wrapper, not the Plyr element itself.

## Implementation Details

Plyr's `destroy()` method swaps the original `<video>` element for an internal clone. If Vue's `v-if` is directly on the Plyr element, the clone becomes orphaned when the conditional unmounts. By placing the `v-if` on a parent wrapper that Vue controls, the entire subtree (including any Plyr-managed clones) is properly removed during teardown.

https://claude.ai/code/session_015kmf5HEazK8JE1MDfEK7JW