### PR TITLE
refactor(playback): consolidate transport state into a usePlayback store

### DIFF
--- a/app/components/cast/CastBar.vue
+++ b/app/components/cast/CastBar.vue
@@ -1,7 +1,7 @@
 <template>
   <v-slide-y-reverse-transition>
     <v-card
-      v-if="(isCastConnected && isMediaLoaded) || isConnecting"
+      v-if="isActive || isConnecting"
       class="cast-bar"
       :class="{ 'cast-bar-desktop': mdAndUp }"
       elevation="8"
@@ -128,21 +128,16 @@
 import { useDisplay } from 'vuetify';
 
 const { mdAndUp } = useDisplay();
+const playback = usePlaybackStore();
 const {
-  isCastConnected,
-  isMediaLoaded,
-  isPaused,
   isMuted,
   volumeLevel,
-  currentTime,
-  duration,
   canSeek,
   canPause,
   castDeviceName,
   castTitle,
   hasCaptions,
   captionsEnabled,
-  isConnecting,
   togglePlay,
   toggleMute,
   setVolume,
@@ -151,6 +146,14 @@ const {
   toggleCaptions,
   stopCasting,
 } = useCast();
+
+// Session fields (position, duration, paused, connecting/active) come from the
+// playback store's cast slice; the device/config fields above stay on useCast
+const isConnecting = computed(() => playback.cast.kind === 'connecting');
+const isActive = computed(() => playback.cast.kind === 'active');
+const isPaused = computed(() => (playback.cast.kind === 'active' ? playback.cast.paused : false));
+const currentTime = computed(() => (playback.cast.kind === 'active' ? playback.cast.position : 0));
+const duration = computed(() => (playback.cast.kind === 'active' ? playback.cast.duration : 0));
 
 // While the user drags the seek slider, show the drag position instead of
 // the (still updating) playback position; only seek on release. After release,

--- a/app/components/cast/CastButton.vue
+++ b/app/components/cast/CastButton.vue
@@ -55,7 +55,12 @@ const tooltipText = computed(() =>
 
 async function onSelectFile(file: MediaFile) {
   const title = uiStore.selectedVideo?.title ?? '';
-  const videoKey = uiStore.selectedVideo?.languageAgnosticNaturalKey ?? '';
-  await castMedia(file.progressiveDownloadURL, title, props.subtitleUrl, props.startTime, videoKey);
+  await castMedia(
+    file.progressiveDownloadURL,
+    title,
+    props.subtitleUrl,
+    props.startTime,
+    uiStore.selectedVideo,
+  );
 }
 </script>

--- a/app/components/player/VideoDialog.vue
+++ b/app/components/player/VideoDialog.vue
@@ -65,7 +65,7 @@
               :src="videoPoster"
             >
               <div class="cast-placeholder-overlay d-flex flex-column align-center justify-center">
-                <v-progress-circular v-if="isConnecting" color="white" indeterminate size="48" />
+                <v-progress-circular v-if="isCastConnecting" color="white" indeterminate size="48" />
 
                 <template v-else>
                   <v-icon color="white" size="56">mdi-cast-connected</v-icon>
@@ -120,7 +120,7 @@
 
         <v-card-actions>
           <CastButton
-            :start-time="localTime"
+            :start-time="localStartTime"
             :subtitle-media="subtitleMedia"
             :subtitle-url="subtitleUrl"
             :video-media="videoMedia"
@@ -165,39 +165,24 @@ const transcriptMobileOpen = computed(
   () => uiStore.transcriptPanel && smAndDown.value && !landscape.value,
 );
 
-const {
-  isCastConnected,
-  isMediaLoaded,
-  isConnecting,
-  castDeviceName,
-  castVideoKey,
-  currentTime: castTime,
-  seekTo: castSeekTo,
-} = useCast();
+const playback = usePlaybackStore();
+const { castDeviceName, seekTo: castSeekTo } = useCast();
 
 const playerEl = ref<HTMLVideoElement | null>(null);
 
 const { loading, videoMedia, subtitleMedia, captionUrl, subtitleUrl }
   = useMediaItems(() => captureResume());
 
-// The cast session is global (one device), so mirror it in this dialog only
-// when the media on the receiver is the video this dialog is showing —
-// otherwise browsing to a different video inherits the cast placeholder, its
-// controls, and the wrong (still-scrolling) transcript
-const isCurrentCastTarget = computed(() =>
-  !!uiStore.selectedVideo
-  && castVideoKey.value === uiStore.selectedVideo.languageAgnosticNaturalKey,
-);
-const isCasting = computed(
-  () => isCurrentCastTarget.value && isCastConnected.value && isMediaLoaded.value,
-);
-// Exclusive playback: from the moment this video's cast session starts
-// connecting until it ends, the cast owns playback and the local player does
-// not exist
-const castActive = computed(
-  () => isCurrentCastTarget.value && (isConnecting.value || isCasting.value),
-);
-const transcriptTime = computed(() => (isCasting.value ? castTime.value : localTime.value));
+// The cast session is global (one device); the store's cast slice carries the
+// video being cast, so this dialog mirrors it only when that video is the one
+// it is showing. Browsing to a different video falls back to local playback.
+const castActive = computed(() => playback.isCastTarget(uiStore.selectedVideo));
+const isCasting = computed(() => playback.isCastingVideo(uiStore.selectedVideo));
+const isCastConnecting = computed(() => castActive.value && !isCasting.value);
+// Local position of the open video — the cast starts here on handoff
+const localStartTime = computed(() => playback.localPositionOf(uiStore.selectedVideo));
+// Transcript clock follows whichever transport owns this video
+const transcriptTime = computed(() => playback.positionFor(uiStore.selectedVideo));
 
 function onSeekTranscript(seconds: number) {
   if (isCasting.value) {
@@ -247,7 +232,6 @@ const availableLanguages = computed(() => {
 });
 
 const {
-  localTime,
   loadPlayer,
   captureResume,
   markResume,
@@ -256,24 +240,15 @@ const {
   destroy: destroyPlayer,
 } = usePlyrPlayer(playerEl, { videoMedia, captionUrl, subtitleUrl, poster: videoPoster });
 
-// Track the cast position so local playback can resume there when it ends
-let lastCastTime = 0;
-watch(castTime, time => {
-  if (isCasting.value && time > 0) {
-    lastCastTime = time;
-  }
-});
-
 // Exclusive playback: destroy the local player when casting takes over
-// (the <video> is v-if'd out); rebuild it at the cast position when the
+// (the <video> is v-if'd out); rebuild it at the last cast position when the
 // cast ends while the dialog is still open
 watch(castActive, active => {
   if (active) {
     destroyPlayer();
   }
   else if (uiStore.videoDialog) {
-    markResume(lastCastTime);
-    lastCastTime = 0;
+    markResume(playback.lastCastPosition);
     nextTick(() => loadPlayer());
   }
 });

--- a/app/composables/useCast.ts
+++ b/app/composables/useCast.ts
@@ -1,3 +1,4 @@
+import type { Video } from '~/types';
 import type { CastWindow, RemotePlayer, RemotePlayerController } from '~/types/cast';
 
 /**
@@ -23,9 +24,6 @@ const canSeek = ref(false);
 const canPause = ref(false);
 const castDeviceName = ref('');
 const castTitle = ref('');
-// Identity of the media currently loaded on the receiver, so a dialog can tell
-// whether the global cast session belongs to the video it is showing
-const castVideoKey = ref('');
 const hasCaptions = ref(false);
 const captionsEnabled = ref(false);
 // True from device selection until media is loaded on the receiver
@@ -37,6 +35,8 @@ let remotePlayerController: RemotePlayerController | null = null;
 let pendingStartTime = 0;
 
 export function useCast() {
+  const playback = usePlaybackStore();
+
   function syncRemotePlayer() {
     if (!remotePlayer) {
       return;
@@ -73,6 +73,20 @@ export function useCast() {
         pendingStartTime = 0;
       }
     }
+
+    // Mirror the receiver into the playback store's cast slice. The connecting
+    // video (set in castMedia) carries through to the active state as identity.
+    if (playback.cast.kind !== 'idle' && remotePlayer.isMediaLoaded) {
+      playback.setCastActive({
+        video: playback.cast.video,
+        position: remotePlayer.currentTime,
+        duration: remotePlayer.duration,
+        paused: remotePlayer.isPaused,
+      });
+    }
+    if (!remotePlayer.isConnected && playback.cast.kind !== 'idle') {
+      playback.castIdle();
+    }
   }
 
   function initCast() {
@@ -108,7 +122,7 @@ export function useCast() {
               || event.sessionState === sessionState.SESSION_ENDED
             ) {
               isConnecting.value = false;
-              castVideoKey.value = '';
+              playback.castIdle();
             }
           },
         );
@@ -144,13 +158,15 @@ export function useCast() {
     title: string,
     subtitleUrl?: string | null,
     startTime?: number,
-    videoKey?: string,
+    video?: Video | null,
   ): Promise<boolean> {
     if (!isAvailable.value) {
       return false;
     }
     castTitle.value = title;
-    castVideoKey.value = videoKey ?? '';
+    if (video) {
+      playback.setCastConnecting(video);
+    }
     pendingStartTime = startTime ?? 0;
     try {
       const w = window as unknown as CastWindow;
@@ -209,7 +225,7 @@ export function useCast() {
     catch {
       isConnecting.value = false;
       pendingStartTime = 0;
-      castVideoKey.value = '';
+      playback.castIdle();
       return false;
     }
   }
@@ -270,21 +286,14 @@ export function useCast() {
 
   return {
     isAvailable,
-    isCastConnected,
-    isMediaLoaded,
-    isPaused,
     isMuted,
     volumeLevel,
-    currentTime,
-    duration,
     canSeek,
     canPause,
     castDeviceName,
     castTitle,
-    castVideoKey,
     hasCaptions,
     captionsEnabled,
-    isConnecting,
     initCast,
     castMedia,
     togglePlay,

--- a/app/composables/usePlyrPlayer.ts
+++ b/app/composables/usePlyrPlayer.ts
@@ -23,13 +23,13 @@ export function usePlyrPlayer(
 ) {
   const languageStore = useLanguageStore();
   const uiStore = useUiStore();
+  const playback = usePlaybackStore();
   const { smAndDown } = useDisplay();
 
   let player: Plyr | undefined = undefined;
   let playerLoadId = 0;
   // Playback position to restore after a language switch rebuilds the player
   let resumeTime = 0;
-  const localTime = ref(0);
 
   let transcriptBtn: HTMLButtonElement | null = null;
 
@@ -113,6 +113,10 @@ export function usePlyrPlayer(
       player.destroy();
     }
 
+    if (uiStore.selectedVideo) {
+      playback.setLocalLoading(uiStore.selectedVideo);
+    }
+
     const tracks: Track[] = [];
     if (source.captionUrl.value) {
       tracks.push({
@@ -148,11 +152,23 @@ export function usePlyrPlayer(
       ...(smAndDown.value ? {} : { fullscreen: { container: '.player-row' } }),
     });
     player.on('ready', injectTranscriptButton);
-
-    localTime.value = 0;
-    player.on('timeupdate', () => {
-      localTime.value = player?.currentTime ?? 0;
+    player.on('ready', () => {
+      if (uiStore.selectedVideo) {
+        playback.setLocalReady(uiStore.selectedVideo);
+      }
     });
+
+    player.on('timeupdate', () => {
+      playback.updateLocal({ position: player?.currentTime ?? 0 });
+    });
+    player.on('loadedmetadata', () => {
+      playback.updateLocal({ duration: player?.duration ?? 0 });
+    });
+    const syncPaused = () => playback.updateLocal({ paused: player?.paused ?? true });
+    player.on('play', syncPaused);
+    player.on('pause', syncPaused);
+    player.on('playing', syncPaused);
+    player.on('ended', syncPaused);
 
     player.source = {
       type: 'video',
@@ -189,7 +205,7 @@ export function usePlyrPlayer(
 
   // Remember the current position so the next loadPlayer restores it
   function captureResume() {
-    resumeTime = player?.currentTime ?? localTime.value;
+    resumeTime = player?.currentTime ?? playback.localPositionOf(uiStore.selectedVideo);
   }
 
   // Explicit position for the next loadPlayer (e.g. resuming after a cast)
@@ -212,7 +228,8 @@ export function usePlyrPlayer(
   function destroy() {
     player?.destroy();
     player = undefined;
+    playback.localIdle();
   }
 
-  return { localTime, loadPlayer, captureResume, markResume, resetResume, seekTo, destroy };
+  return { loadPlayer, captureResume, markResume, resetResume, seekTo, destroy };
 }

--- a/app/stores/playback.ts
+++ b/app/stores/playback.ts
@@ -1,0 +1,115 @@
+import type { Video } from '~/types';
+import type { CastState, LocalState } from '~/types/playback';
+
+/**
+ * Single owner of playback session state, one slice per transport. Cast and
+ * local can be non-idle at the same time (the cast session is app-global and
+ * survives dialog close; the local player is dialog-scoped), so they are kept
+ * as two concurrent slices rather than one exclusive union.
+ *
+ * The two drivers write here: `useCast` drives `cast`, `usePlyrPlayer` drives
+ * `local`. Components read the identity-aware getters for the video they show.
+ */
+export const usePlaybackStore = defineStore('playback', () => {
+  const cast = ref<CastState>({ kind: 'idle' });
+  const local = ref<LocalState>({ kind: 'idle' });
+  // Last known cast position, retained across `castIdle` so the local player
+  // can resume there on the cast → local handoff (disconnect while open)
+  const lastCastPosition = ref(0);
+
+  function keyOf(video: Video) {
+    return video.languageAgnosticNaturalKey;
+  }
+
+  // --- cast slice (driven by useCast) ---
+  function setCastConnecting(video: Video) {
+    cast.value = { kind: 'connecting', video };
+    lastCastPosition.value = 0;
+  }
+  function setCastActive(patch: {
+    video: Video;
+    position: number;
+    duration: number;
+    paused: boolean;
+  }) {
+    cast.value = { kind: 'active', ...patch };
+    if (patch.position > 0) {
+      lastCastPosition.value = patch.position;
+    }
+  }
+  function updateCast(patch: Partial<{ position: number; duration: number; paused: boolean }>) {
+    if (cast.value.kind !== 'active') {
+      return;
+    }
+    cast.value = { ...cast.value, ...patch };
+    if (patch.position !== undefined && patch.position > 0) {
+      lastCastPosition.value = patch.position;
+    }
+  }
+  function castIdle() {
+    cast.value = { kind: 'idle' };
+  }
+
+  // --- local slice (driven by usePlyrPlayer) ---
+  function setLocalLoading(video: Video) {
+    local.value = { kind: 'loading', video };
+  }
+  function setLocalReady(video: Video) {
+    local.value = { kind: 'ready', video, position: 0, duration: 0, paused: true };
+  }
+  function updateLocal(patch: Partial<{ position: number; duration: number; paused: boolean }>) {
+    if (local.value.kind !== 'ready') {
+      return;
+    }
+    local.value = { ...local.value, ...patch };
+  }
+  function localIdle() {
+    local.value = { kind: 'idle' };
+  }
+
+  // --- identity-aware reads (for a dialog's selectedVideo) ---
+  function isCastTarget(video: Video | null): boolean {
+    if (!video) {
+      return false;
+    }
+    return (cast.value.kind === 'connecting' || cast.value.kind === 'active')
+      && keyOf(cast.value.video) === keyOf(video);
+  }
+  function isCastingVideo(video: Video | null): boolean {
+    if (!video) {
+      return false;
+    }
+    return cast.value.kind === 'active' && keyOf(cast.value.video) === keyOf(video);
+  }
+  function localPositionOf(video: Video | null): number {
+    if (video && local.value.kind === 'ready' && keyOf(local.value.video) === keyOf(video)) {
+      return local.value.position;
+    }
+    return 0;
+  }
+  // Transcript clock: the cast position when this video is casting, else local
+  function positionFor(video: Video | null): number {
+    if (isCastingVideo(video) && cast.value.kind === 'active') {
+      return cast.value.position;
+    }
+    return localPositionOf(video);
+  }
+
+  return {
+    cast,
+    local,
+    lastCastPosition,
+    setCastConnecting,
+    setCastActive,
+    updateCast,
+    castIdle,
+    setLocalLoading,
+    setLocalReady,
+    updateLocal,
+    localIdle,
+    isCastTarget,
+    isCastingVideo,
+    localPositionOf,
+    positionFor,
+  };
+});

--- a/app/types/playback.ts
+++ b/app/types/playback.ts
@@ -1,0 +1,19 @@
+import type { Video } from '~/types';
+
+/**
+ * Per-media playback session state for each transport. The `Video` is carried
+ * in every non-idle state so a consumer can tell *which* video a transport is
+ * playing (identity) without a separate key. Device/config state (volume,
+ * device name, captions, seek/pause capability) is NOT here — it lives as refs
+ * in `useCast`, since it is not per-media.
+ */
+
+export type CastState =
+  | { kind: 'idle' }
+  | { kind: 'connecting'; video: Video }
+  | { kind: 'active'; video: Video; position: number; duration: number; paused: boolean };
+
+export type LocalState =
+  | { kind: 'idle' }
+  | { kind: 'loading'; video: Video }
+  | { kind: 'ready'; video: Video; position: number; duration: number; paused: boolean };


### PR DESCRIPTION
Playback state was scattered across four owners with three separate handoff-position variables, and components derived "is this video casting" from a soup of global cast booleans (the interim castVideoKey side-ref being one symptom).

Introduce a usePlayback Pinia store that models each transport as an explicit discriminated union carrying the Video (identity for free):

- types/playback.ts: CastState / LocalState (idle | connecting/loading | active/ready with position, duration, paused).
- stores/playback.ts: two concurrent slices (cast is app-global, local is dialog-scoped, so they coexist) plus identity-aware reads isCastTarget / isCastingVideo / positionFor, and lastCastPosition retained across castIdle for the cast->local handoff.

useCast and usePlyrPlayer become drivers that emit into the store; useCast loses castVideoKey (identity now lives in the union) and its now-unread session exports. usePlyrPlayer gains play/pause/ended wiring so local paused state is tracked (previously it was not tracked at all) and drops the localTime ref.

VideoDialog, CastBar and CastButton read the store; VideoDialog drops the redundant lastCastTime tracker. Coexistence is preserved: casting A while opening B shows B playing locally with the cast bar still driving A.


Claude-Session: https://claude.ai/code/session_015kmf5HEazK8JE1MDfEK7JW