### PR TITLE
fix(eslint): enable Vue support so linting works

### DIFF
--- a/app/types/playback.ts
+++ b/app/types/playback.ts
@@ -8,12 +8,12 @@ import type { Video } from '~/types';
  * in `useCast`, since it is not per-media.
  */
 
-export type CastState =
-  | { kind: 'idle' }
-  | { kind: 'connecting'; video: Video }
-  | { kind: 'active'; video: Video; position: number; duration: number; paused: boolean };
+export type CastState
+  = | { kind: 'idle' }
+    | { kind: 'connecting'; video: Video }
+    | { kind: 'active'; video: Video; position: number; duration: number; paused: boolean };
 
-export type LocalState =
-  | { kind: 'idle' }
-  | { kind: 'loading'; video: Video }
-  | { kind: 'ready'; video: Video; position: number; duration: number; paused: boolean };
+export type LocalState
+  = | { kind: 'idle' }
+    | { kind: 'loading'; video: Video }
+    | { kind: 'ready'; video: Video; position: number; duration: number; paused: boolean };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,7 @@ import vuetify from 'eslint-config-vuetify';
 import withNuxt from './.nuxt/eslint.config.mjs';
 
 export default withNuxt(
-  vuetify({ ts: true }),
+  vuetify({ ts: true, vue: true }),
   {
     rules: {
       'prefer-template': 'error',


### PR DESCRIPTION
## Problem

`pnpm lint` is broken. Depending on the entry point it fails two ways:

- Linting the `app` dir: **config load error** — *"A configuration object specifies rule `vue/no-multiple-template-root`, but could not find plugin `vue`."*
- Linting a `.vue` file directly: **parse error** — *"Unexpected token `<`"* (no `vue-eslint-parser` attached).

Plain `.ts` files lint fine; only the Vue toolchain is missing.

## Root cause

`eslint-config-vuetify` auto-detects Vue by probing for a **top-level `vue` dependency**. In this project Vue is only a *transitive* dependency of Nuxt — there is no `node_modules/vue` at the top level — so auto-detection silently skips **all** Vue support: no `vue` plugin, no `vue-eslint-parser`, no `vue/*` rules. The vuetify config still references `vue/*` rules, which then have no backing plugin.

This is a toolchain/resolution issue independent of any source change; it reproduces on a clean `pnpm install`.

## Fix

Pass `vue: true` explicitly to `eslint-config-vuetify` so Vue support is registered regardless of hoisting:

```js
vuetify({ ts: true, vue: true })
```

With this, the resolved flat config grows from 20 → 27 objects and now includes the vue plugin, `vue-eslint-parser` for `.vue` files, and the `vue/*` rules.

The one lint error this surfaced (`@stylistic/operator-linebreak` on the `playback.ts` union types) is applied via `--fix`.

## Verification

- `pnpm lint` → exit 0, clean
- `pnpm build` (runs `vue-tsc` type-check) → exit 0, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEsF5Mrq2w9CFeawyfuBYb)_