### PR TITLE
Fix Cast device picker UX: defer connecting state until device selected

### DIFF
--- a/app/components/cast/CastButton.vue
+++ b/app/components/cast/CastButton.vue
@@ -7,7 +7,7 @@
             class="mr-2"
             color="primary"
             :disabled="!castAvailable"
-            :loading="!videoMedia || !subtitleMedia"
+            :loading="!videoMedia || !subtitleMedia || isAwaitingDevice"
             prepend-icon="mdi-cast"
             variant="elevated"
             v-bind="{ ...menuProps, ...tooltipProps }"
@@ -45,7 +45,7 @@ const props = defineProps<{
 
 const languageStore = useLanguageStore();
 const uiStore = useUiStore();
-const { isAvailable: castAvailable, castMedia } = useCast();
+const { isAvailable: castAvailable, isAwaitingDevice, castMedia } = useCast();
 
 const tooltipText = computed(() =>
   props.subtitleUrl

--- a/app/composables/useCast.ts
+++ b/app/composables/useCast.ts
@@ -13,9 +13,7 @@ import type { CastWindow, RemotePlayer, RemotePlayerController } from '~/types/c
 
 // Shared across all component instances
 const isAvailable = ref(false);
-const isCastConnected = ref(false);
 const isMediaLoaded = ref(false);
-const isPaused = ref(false);
 const isMuted = ref(false);
 const volumeLevel = ref(1);
 const currentTime = ref(0);
@@ -51,9 +49,7 @@ export function useCast() {
     // a false → true transition marks the *new* media as loaded and ends the
     // connecting state
     const mediaJustLoaded = !isMediaLoaded.value && remotePlayer.isMediaLoaded;
-    isCastConnected.value = remotePlayer.isConnected;
     isMediaLoaded.value = remotePlayer.isMediaLoaded;
-    isPaused.value = remotePlayer.isPaused;
     isMuted.value = remotePlayer.isMuted;
     volumeLevel.value = remotePlayer.volumeLevel;
     currentTime.value = remotePlayer.currentTime;

--- a/app/composables/useCast.ts
+++ b/app/composables/useCast.ts
@@ -28,6 +28,9 @@ const hasCaptions = ref(false);
 const captionsEnabled = ref(false);
 // True from device selection until media is loaded on the receiver
 const isConnecting = ref(false);
+// True while the device picker is open (requestSession pending). Drives only
+// the CastButton's loading state — no session exists yet, so nothing else
+const isAwaitingDevice = ref(false);
 
 let remotePlayer: RemotePlayer | null = null;
 let remotePlayerController: RemotePlayerController | null = null;
@@ -196,7 +199,15 @@ export function useCast() {
         // Opens the device picker. The connecting state is deferred to the
         // SESSION_STARTING handler (fires once a device is picked) so the live
         // <video> isn't torn down — and the picker closed — while it's open.
-        await context.requestSession();
+        // The picker-open window has no SDK event, so the CastButton spinner is
+        // driven manually across the pending requestSession promise.
+        isAwaitingDevice.value = true;
+        try {
+          await context.requestSession();
+        }
+        finally {
+          isAwaitingDevice.value = false;
+        }
       }
 
       const mediaInfo = new w.chrome!.cast.media.MediaInfo(videoUrl, 'video/mp4');
@@ -309,6 +320,7 @@ export function useCast() {
 
   return {
     isAvailable,
+    isAwaitingDevice,
     isMuted,
     volumeLevel,
     canSeek,

--- a/app/composables/useCast.ts
+++ b/app/composables/useCast.ts
@@ -33,6 +33,9 @@ let remotePlayer: RemotePlayer | null = null;
 let remotePlayerController: RemotePlayerController | null = null;
 // Start position for the media currently being loaded (local → cast handoff)
 let pendingStartTime = 0;
+// Video awaiting a device pick — the connecting state is entered only once a
+// device is chosen (SESSION_STARTING), not while the picker is still open
+let pendingCastVideo: Video | null = null;
 
 export function useCast() {
   const playback = usePlaybackStore();
@@ -111,13 +114,21 @@ export function useCast() {
           w.cast!.framework.RemotePlayerEventType.ANY_CHANGE,
           syncRemotePlayer,
         );
-        // SESSION_STARTING fires once the user picks a device — from there
-        // until the media is actually loaded the bar shows a connecting state
+        // SESSION_STARTING fires once the user picks a device. Only here is it
+        // safe to enter the connecting state (which tears the local player down
+        // and shows the connecting UI) — doing it earlier, while the device
+        // picker is still open, removes the live <video> and closes the picker.
         context.addEventListener(
           w.cast!.framework.CastContextEventType.SESSION_STATE_CHANGED,
           event => {
             const sessionState = w.cast!.framework.SessionState;
             if (event.sessionState === sessionState.SESSION_STARTING) {
+              if (pendingCastVideo) {
+                // Hand off at the live local position — the video kept playing
+                // while the picker was open
+                pendingStartTime = playback.localPositionOf(pendingCastVideo) || pendingStartTime;
+                playback.setCastConnecting(pendingCastVideo, pendingStartTime);
+              }
               isConnecting.value = true;
             }
             else if (
@@ -125,6 +136,7 @@ export function useCast() {
               || event.sessionState === sessionState.SESSION_ENDED
             ) {
               isConnecting.value = false;
+              pendingCastVideo = null;
               playback.castIdle();
             }
           },
@@ -168,18 +180,22 @@ export function useCast() {
     }
     castTitle.value = title;
     pendingStartTime = startTime ?? 0;
-    if (video) {
-      playback.setCastConnecting(video, pendingStartTime);
-    }
+    pendingCastVideo = video ?? null;
     try {
       const w = window as unknown as CastWindow;
       const context = w.cast!.framework.CastContext.getInstance();
       if (context.getCurrentSession()) {
-        // Already casting — load the new media into the running session.
-        // No SESSION_STARTING event fires here, so flag the switch manually.
+        // Already casting — no device picker opens, so enter the connecting
+        // state now and load the new media into the running session.
+        if (video) {
+          playback.setCastConnecting(video, pendingStartTime);
+        }
         isConnecting.value = true;
       }
       else {
+        // Opens the device picker. The connecting state is deferred to the
+        // SESSION_STARTING handler (fires once a device is picked) so the live
+        // <video> isn't torn down — and the picker closed — while it's open.
         await context.requestSession();
       }
 
@@ -212,8 +228,10 @@ export function useCast() {
       if (subtitleUrl) {
         request.activeTrackIds = [1];
       }
-      if (startTime && startTime > 0) {
-        request.currentTime = startTime;
+      // pendingStartTime is re-read at SESSION_STARTING, so it reflects the
+      // live local position at handoff rather than the button-press snapshot
+      if (pendingStartTime > 0) {
+        request.currentTime = pendingStartTime;
       }
 
       const session = context.getCurrentSession();
@@ -223,11 +241,13 @@ export function useCast() {
       await session!.loadMedia(request);
       hasCaptions.value = !!subtitleUrl;
       captionsEnabled.value = !!subtitleUrl;
+      pendingCastVideo = null;
       return true;
     }
     catch {
       isConnecting.value = false;
       pendingStartTime = 0;
+      pendingCastVideo = null;
       playback.castIdle();
       return false;
     }

--- a/app/composables/useCast.ts
+++ b/app/composables/useCast.ts
@@ -84,7 +84,10 @@ export function useCast() {
         paused: remotePlayer.isPaused,
       });
     }
-    if (!remotePlayer.isConnected && playback.cast.kind !== 'idle') {
+    // While connecting (device picker open, or media still loading) a
+    // disconnected RemotePlayer is expected — the "waiting for device" window.
+    // Only a drop after we were actually connected should idle the cast slice.
+    if (!isConnecting.value && !remotePlayer.isConnected && playback.cast.kind !== 'idle') {
       playback.castIdle();
     }
   }
@@ -164,10 +167,10 @@ export function useCast() {
       return false;
     }
     castTitle.value = title;
-    if (video) {
-      playback.setCastConnecting(video);
-    }
     pendingStartTime = startTime ?? 0;
+    if (video) {
+      playback.setCastConnecting(video, pendingStartTime);
+    }
     try {
       const w = window as unknown as CastWindow;
       const context = w.cast!.framework.CastContext.getInstance();

--- a/app/stores/playback.ts
+++ b/app/stores/playback.ts
@@ -40,15 +40,6 @@ export const usePlaybackStore = defineStore('playback', () => {
       lastCastPosition.value = patch.position;
     }
   }
-  function updateCast(patch: Partial<{ position: number; duration: number; paused: boolean }>) {
-    if (cast.value.kind !== 'active') {
-      return;
-    }
-    cast.value = { ...cast.value, ...patch };
-    if (patch.position !== undefined && patch.position > 0) {
-      lastCastPosition.value = patch.position;
-    }
-  }
   function castIdle() {
     cast.value = { kind: 'idle' };
   }
@@ -104,7 +95,6 @@ export const usePlaybackStore = defineStore('playback', () => {
     lastCastPosition,
     setCastConnecting,
     setCastActive,
-    updateCast,
     castIdle,
     setLocalLoading,
     setLocalReady,

--- a/app/stores/playback.ts
+++ b/app/stores/playback.ts
@@ -22,9 +22,12 @@ export const usePlaybackStore = defineStore('playback', () => {
   }
 
   // --- cast slice (driven by useCast) ---
-  function setCastConnecting(video: Video) {
+  // Seed lastCastPosition with the local handoff position so a cancelled or
+  // failed cast (e.g. the device picker dismissed without a selection) restores
+  // the local player to where it was, not to 0
+  function setCastConnecting(video: Video, startPosition = 0) {
     cast.value = { kind: 'connecting', video };
-    lastCastPosition.value = 0;
+    lastCastPosition.value = startPosition;
   }
   function setCastActive(patch: {
     video: Video;


### PR DESCRIPTION
## Summary

Fixes a critical UX issue where opening the Cast device picker would immediately tear down the local video player and show a connecting spinner, then close the picker if the user dismissed it without selecting a device. The connecting state is now deferred until a device is actually selected (SESSION_STARTING event), allowing the picker to remain open over the live video.

## Key Changes

- **Deferred connecting state**: `isConnecting` is now only set to `true` when SESSION_STARTING fires (device picked), not when `requestSession()` is called (picker opens). This keeps the local `<video>` element in the DOM while the picker is open.

- **New `isAwaitingDevice` flag**: Tracks the `requestSession()` promise window separately to drive only the CastButton's loading spinner during device selection, without affecting the player UI.

- **Pending video handoff**: Introduced `pendingCastVideo` to store the video awaiting a device pick. At SESSION_STARTING, the live local playback position is captured and passed to `setCastConnecting()` as the handoff point, so cancelled/failed casts restore to the correct position rather than 0.

- **Improved disconnection handling**: The check for unexpected disconnects now respects the `isConnecting` window — a disconnected RemotePlayer is expected while connecting or waiting for a device, so only drops after a confirmed connection trigger the idle state.

- **Store API update**: `setCastConnecting()` now accepts an optional `startPosition` parameter (defaults to 0) to seed `lastCastPosition` with the handoff point.

- **Removed unused state**: Deleted `isCastConnected` and `isPaused` refs that were assigned but never read.

## Implementation Details

- The device picker has no SDK event, so `isAwaitingDevice` is manually managed around the `requestSession()` promise via try/finally.
- `pendingStartTime` is re-read at SESSION_STARTING to capture the live local position at handoff rather than the button-press snapshot, accounting for playback during the picker-open window.
- The `updateCast()` store mutation was removed as it's no longer needed with the improved state management.

https://claude.ai/code/session_01MFbXNiZ22B6pRMNZv6CBik