### PR TITLE
feat: on-site guide dialog, footer, and feedback link

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -20,10 +20,9 @@
         </template>
 
         <v-btn
-          href="https://github.com/semkeijsper/jw-cast#handleiding"
           prepend-icon="mdi-book-open-blank-variant"
-          target="_blank"
           variant="text"
+          @click="uiStore.setTutorialDialog(true)"
         >
           <span v-if="!xs">{{ guideButtonText }}</span>
         </v-btn>
@@ -32,6 +31,7 @@
 
     <v-main>
       <NuxtPage />
+      <AppFooter />
     </v-main>
 
     <CastBar />
@@ -39,6 +39,7 @@
     <SearchDialog />
     <VideoDialog />
     <GetNotifiedDialog />
+    <TutorialDialog />
   </v-app>
 </template>
 

--- a/app/components/common/AppFooter.vue
+++ b/app/components/common/AppFooter.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-footer class="footer text-caption d-flex justify-center ga-4 py-6" color="transparent">
+    <v-btn
+      :href="GITHUB_URL"
+      prepend-icon="mdi-github"
+      rel="noopener"
+      size="small"
+      target="_blank"
+      variant="text"
+    >
+      {{ languageStore.t('lnkSource') }}
+    </v-btn>
+
+    <v-btn
+      :href="FEEDBACK_URL"
+      prepend-icon="mdi-comment-quote-outline"
+      rel="noopener"
+      size="small"
+      target="_blank"
+      variant="text"
+    >
+      {{ languageStore.t('feedback') }}
+    </v-btn>
+  </v-footer>
+</template>
+
+<script setup lang="ts">
+import { FEEDBACK_URL, GITHUB_URL } from '~/config/links';
+
+const languageStore = useLanguageStore();
+</script>
+
+<style scoped>
+.footer {
+  opacity: 0.7;
+}
+</style>

--- a/app/components/common/TutorialDialog.vue
+++ b/app/components/common/TutorialDialog.vue
@@ -1,0 +1,116 @@
+<template>
+  <v-dialog v-model="dialog" :fullscreen="xs" max-width="560px">
+    <v-card>
+      <v-toolbar color="primary" density="compact">
+        <v-toolbar-title>{{ languageStore.t('tutorialTitle') }}</v-toolbar-title>
+
+        <template #append>
+          <v-btn icon @click="dialog = false">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </template>
+      </v-toolbar>
+
+      <v-window v-model="step" class="pt-6">
+        <v-window-item v-for="(item, i) in steps" :key="i" :value="i">
+          <v-card-text class="text-center pb-2">
+            <v-icon class="mb-4" color="primary" size="64">{{ item.icon }}</v-icon>
+            <h3 class="text-h6 mb-2">{{ item.title }}</h3>
+            <p class="text-body-1">{{ item.body }}</p>
+          </v-card-text>
+        </v-window-item>
+      </v-window>
+
+      <div class="d-flex justify-center py-2">
+        <span
+          v-for="(_, i) in steps"
+          :key="i"
+          class="dot mx-1"
+          :class="{ 'dot--active': i === step }"
+        />
+      </div>
+
+      <v-card-actions class="px-4 pb-4">
+        <v-btn
+          :disabled="step === 0"
+          prepend-icon="mdi-chevron-left"
+          variant="text"
+          @click="step--"
+        >
+          {{ languageStore.t('btnBack') }}
+        </v-btn>
+
+        <v-btn
+          :href="FEEDBACK_URL"
+          prepend-icon="mdi-comment-quote-outline"
+          rel="noopener"
+          size="small"
+          target="_blank"
+          variant="text"
+        >
+          {{ languageStore.t('feedback') }}
+        </v-btn>
+
+        <v-spacer />
+
+        <v-btn
+          append-icon="mdi-chevron-right"
+          color="primary"
+          variant="flat"
+          @click="onNext"
+        >
+          {{ isLast ? languageStore.t('btnDone') : languageStore.t('btnNext') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { useDisplay } from 'vuetify';
+import { FEEDBACK_URL } from '~/config/links';
+
+const languageStore = useLanguageStore();
+const uiStore = useUiStore();
+const { xs } = useDisplay();
+
+const step = ref(0);
+
+const dialog = computed({
+  get: () => uiStore.tutorialDialog,
+  set: v => uiStore.setTutorialDialog(v),
+});
+
+const steps = computed(() => languageStore.tutorialSteps);
+const isLast = computed(() => step.value >= steps.value.length - 1);
+
+watch(dialog, open => {
+  if (open) {
+    step.value = 0;
+  }
+});
+
+function onNext() {
+  if (isLast.value) {
+    dialog.value = false;
+  }
+  else {
+    step.value++;
+  }
+}
+</script>
+
+<style scoped>
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgb(var(--v-theme-on-surface));
+  opacity: 0.25;
+  transition: opacity 0.2s;
+}
+
+.dot--active {
+  opacity: 0.9;
+}
+</style>

--- a/app/config/links.ts
+++ b/app/config/links.ts
@@ -1,0 +1,4 @@
+export const GITHUB_URL = 'https://github.com/semkeijsper/jw-cast';
+
+// TODO: replace with the real Google Form feedback URL
+export const FEEDBACK_URL = 'https://forms.gle/REPLACE_ME';

--- a/app/config/tutorialSteps.ts
+++ b/app/config/tutorialSteps.ts
@@ -1,0 +1,53 @@
+import type { TutorialStep } from '~/types';
+
+/**
+ * On-site tutorial content shown in TutorialDialog, keyed by locale with an
+ * `en` fallback (mirrors whatsappChannels). Add a locale block to translate
+ * the walkthrough into a new language.
+ */
+export const tutorialSteps: Record<string, TutorialStep[]> = {
+  nl: [
+    {
+      icon: 'mdi-translate',
+      title: 'Kies je talen',
+      body: 'Selecteer bovenaan de audiotaal en de ondertiteltaal los van elkaar. Zo kun je een video in de ene taal beluisteren en in een andere taal meelezen.',
+    },
+    {
+      icon: 'mdi-play-circle-outline',
+      title: 'Bekijk de video',
+      body: 'Klik op een video om de speler te openen. Wissel gerust van taal terwijl je kijkt — je positie blijft behouden. Open het transcript om mee te lezen en naar een zin te springen.',
+    },
+    {
+      icon: 'mdi-cast',
+      title: 'Cast naar je tv',
+      body: 'Met een Chromecast in de buurt verschijnt de castknop. Stream de video rechtstreeks naar je tv; de bediening staat onderin in de castbalk.',
+    },
+    {
+      icon: 'mdi-download',
+      title: 'Download of open op jw.org',
+      body: 'Via het downloadmenu haal je de videobestanden of ondertitels op, of open je de video rechtstreeks op jw.org.',
+    },
+  ],
+  en: [
+    {
+      icon: 'mdi-translate',
+      title: 'Pick your languages',
+      body: 'At the top, choose the audio language and the subtitle language independently. Listen in one language while reading along in another.',
+    },
+    {
+      icon: 'mdi-play-circle-outline',
+      title: 'Watch the video',
+      body: 'Click a video to open the player. Switch languages while watching — your position is kept. Open the transcript to read along and jump to any line.',
+    },
+    {
+      icon: 'mdi-cast',
+      title: 'Cast to your TV',
+      body: 'With a Chromecast nearby the cast button appears. Stream the video straight to your TV; the controls live in the cast bar at the bottom.',
+    },
+    {
+      icon: 'mdi-download',
+      title: 'Download or open on jw.org',
+      body: 'Use the download menu to grab the video files or subtitles, or open the video directly on jw.org.',
+    },
+  ],
+};

--- a/app/config/uiStrings.ts
+++ b/app/config/uiStrings.ts
@@ -18,6 +18,12 @@ import type { Translations } from '~/types';
 export const uiStrings: Record<string, Translations> = {
   en: {
     guide: 'Guide',
+    tutorialTitle: 'How to use JW Cast',
+    feedback: 'Feedback',
+    btnBack: 'Back',
+    btnNext: 'Next',
+    btnDone: 'Done',
+    lnkSource: 'Source on GitHub',
     lnkSearch: 'Search',
     searchPlaceholder: 'Search or paste jw.org link...',
     searchFailed: 'Search failed. Please try again later.',
@@ -42,6 +48,12 @@ export const uiStrings: Record<string, Translations> = {
   },
   nl: {
     guide: 'Handleiding',
+    tutorialTitle: 'JW Cast gebruiken',
+    feedback: 'Feedback',
+    btnBack: 'Vorige',
+    btnNext: 'Volgende',
+    btnDone: 'Klaar',
+    lnkSource: 'Broncode op GitHub',
     searchPlaceholder: 'Zoek of plak jw.org link...',
     searchFailed: 'Zoeken is mislukt. Probeer het later opnieuw.',
     loadFailed: 'Laden is mislukt. Probeer het later opnieuw.',

--- a/app/stores/language.ts
+++ b/app/stores/language.ts
@@ -1,4 +1,5 @@
 import type { Language, Translations } from '~/types';
+import { tutorialSteps } from '~/config/tutorialSteps';
 import { uiStrings } from '~/config/uiStrings';
 import { whatsappChannels } from '~/config/whatsappChannels';
 
@@ -40,6 +41,8 @@ export const useLanguageStore = defineStore('language', () => {
   );
 
   const whatsappChannel = computed(() => whatsappChannels[siteLanguage.value]);
+
+  const tutorialSteps_ = computed(() => tutorialSteps[siteLanguage.value] ?? tutorialSteps.en!);
 
   // UI string resolution: jw.org API translation → local dict → English
   function t(key: string): string {
@@ -84,6 +87,7 @@ export const useLanguageStore = defineStore('language', () => {
     videoLanguageInfo,
     subtitleLanguageInfo,
     whatsappChannel,
+    tutorialSteps: tutorialSteps_,
     t,
     findLanguageByCode,
     findLanguageByLocale,

--- a/app/stores/ui.ts
+++ b/app/stores/ui.ts
@@ -6,6 +6,7 @@ export const useUiStore = defineStore('ui', () => {
   const transcriptPanel = ref(false);
   const transcriptExpanded = ref(false);
   const getNotifiedDialog = ref(false);
+  const tutorialDialog = ref(false);
   const selectedVideo = ref<Video | null>(null);
 
   // Mutations
@@ -27,6 +28,9 @@ export const useUiStore = defineStore('ui', () => {
   function setGetNotifiedDialog(value: boolean) {
     getNotifiedDialog.value = value;
   }
+  function setTutorialDialog(value: boolean) {
+    tutorialDialog.value = value;
+  }
   function setSelectedVideo(value: Video | null) {
     selectedVideo.value = value;
   }
@@ -44,12 +48,14 @@ export const useUiStore = defineStore('ui', () => {
     transcriptPanel,
     transcriptExpanded,
     getNotifiedDialog,
+    tutorialDialog,
     selectedVideo,
     setSearchDialog,
     setVideoDialog,
     setTranscriptPanel,
     setTranscriptExpanded,
     setGetNotifiedDialog,
+    setTutorialDialog,
     setSelectedVideo,
     openVideo,
   };

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -74,3 +74,10 @@ export interface WhatsAppChannel {
   description: string;
   buttonLabel: string;
 }
+
+export interface TutorialStep {
+  /** mdi icon name e.g. `mdi-translate` */
+  icon: string;
+  title: string;
+  body: string;
+}

--- a/test/nuxt/stores/ui.test.ts
+++ b/test/nuxt/stores/ui.test.ts
@@ -14,6 +14,15 @@ describe('ui store', () => {
     expect(s.videoDialog).toBe(true);
   });
 
+  it('setTutorialDialog toggles the tutorial flag', () => {
+    const s = useUiStore();
+    expect(s.tutorialDialog).toBe(false);
+    s.setTutorialDialog(true);
+    expect(s.tutorialDialog).toBe(true);
+    s.setTutorialDialog(false);
+    expect(s.tutorialDialog).toBe(false);
+  });
+
   it('closing the transcript panel also collapses the expanded state', () => {
     const s = useUiStore();
     s.setTranscriptPanel(true);


### PR DESCRIPTION
## What & why

The app-bar **Guide** button used to open the GitHub README anchor in a new tab, kicking users off-site to a Dutch markdown file. This replaces it with an **in-app stepped tutorial**, and adds a small **footer** so people can find the source and leave feedback.

## Changes

- **TutorialDialog.vue** — Guide button now opens an in-app `v-window` stepped walkthrough (pick languages → play → cast → download) instead of an external link. Back / Next / Done, dot indicator, fullscreen on mobile. Modeled on `GetNotifiedDialog.vue`.
- **AppFooter.vue** — low-key footer rendered inside `<v-main>` (so the fixed `CastBar` never covers it) with a GitHub source link and a feedback link.
- **config/tutorialSteps.ts** — locale-keyed step content (nl + en), same pattern as `whatsappChannels.ts`.
- **config/links.ts** — shared `GITHUB_URL` + placeholder `FEEDBACK_URL`.
- **ui store** — `tutorialDialog` flag + `setTutorialDialog`.
- **language store** — `tutorialSteps` getter.
- **uiStrings** — new keys (`tutorialTitle`, `feedback`, `btnBack`/`btnNext`/`btnDone`, `lnkSource`) in `en` + `nl`; other locales fall back to `en`.

## Follow-up

⚠️ `FEEDBACK_URL` in `app/config/links.ts` is a **placeholder** (`https://forms.gle/REPLACE_ME`) — swap in the real Google Form URL before/after merge.

## Verification

- `pnpm lint` — clean
- `pnpm test` — 50 passed (incl. a new ui-store assertion for `setTutorialDialog`)
- `vue-tsc` — 0 type errors

Manual: Guide opens the dialog (no new tab), Back/Next cycle steps, feedback link (dialog + footer) opens in a new tab, footer sits at page bottom clear of CastBar, nl/en localize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HPb5VcJ7zhsMpRmH2kmYF

---
_Generated by [Claude Code](https://claude.ai/code/session_018HPb5VcJ7zhsMpRmH2kmYF)_