### PR TITLE
fix(cast): restore the cast session after a mid-cast reload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,11 +245,16 @@ Single owner of playback-session state, one slice per transport (`types/playback
 | `cast` | Cast slice (`idle` / `connecting` / `active`), written by `useCast` |
 | `local` | Local-player slice (`idle` / `loading` / `ready`), written by `usePlyrPlayer` |
 | `lastCastPosition` | Position retained across `castIdle` so the cast → local handoff resumes there |
+| `castTargetKey` | The persisted cast identity — see below |
 | `setCastConnecting` / `setCastActive` / `castIdle` | Cast-slice mutations (connecting seeds `lastCastPosition` for the cancel/fallback case) |
 | `setLocalLoading` / `setLocalReady` / `updateLocal` / `localIdle` | Local-slice mutations |
 | `isCastTarget(v)` / `isCastingVideo(v)` / `localPositionOf(v)` / `positionFor(v)` | Identity-aware reads for a dialog's `selectedVideo` (`positionFor` is the transcript clock: cast position when casting, else local) |
 
 Mutations are `set*` functions. Async work stays in components/composables, calling `utils/api.ts` helpers.
+
+**The cast slice is keyed, the local slice is not.** `CastState` carries a `videoKey` (`languageAgnosticNaturalKey`) rather than a `Video`, because a cast session outlives the page: it must be restorable from storage after a reload (see Chromecast → Reload mid-cast). `LocalState` is dialog-scoped and keeps the real object. The identity-aware getters still take `Video | null`, so consumers never handle keys themselves.
+
+Persistence: this store persists **only** `castTargetKey`, via `piniaPluginPersistedstate.sessionStorage()` — per-tab, and deliberately *not* the language store's pinned `'app'` cookie (the plugin's Nuxt default is cookies, so the `storage` option must be passed explicitly or this would ride on every request).
 
 ## UI Strings
 
@@ -322,7 +327,7 @@ Mobile ergonomics: the dialog auto-enters fullscreen when the device rotates to 
 
 `cast/CastButton.vue` is disabled when the Cast SDK is unavailable (e.g. non-Chromium browsers). Exclusive-cast and handoff behavior needs manual verification with real Chromecast hardware — it can't be exercised headless; `test/nuxt/composables/useCast.test.ts` covers the session handshake against a fake SDK.
 
-Known gap: reloading mid-cast auto-rejoins the session, but the playback store's `cast` slice keys on a `Video` object that can't be recovered after reload, so `CastBar` stays hidden until the next `castMedia` call.
+**Reload mid-cast:** `ORIGIN_SCOPED` auto-join rejoins the running session, so the receiver keeps playing — but the store's `cast` slice starts idle and `syncRemotePlayer` only writes to a non-idle slice, so nothing would ever bring it back. `restoreResumedSession()` re-adopts it from the persisted `castTargetKey`, then lets `RemotePlayer` events refill title/device/position. It runs from both the `SESSION_RESUMED` handler *and* the tail of `configureCast()`, because auto-join can finish before `app.vue`'s `onMounted` attaches the listener. Caption state is read back off `getMediaSession()`; it is the one thing a `LoadRequest` knows that a rejoined session doesn't. **The breadcrumb is per-tab** — a *new* tab on the same origin auto-joins but has no key, so it shows no CastBar. That is deliberate: cross-tab restore needs localStorage plus invalidation on every session end.
 
 ## Search
 
@@ -400,7 +405,7 @@ So: **keep staging-specific behavior in the workflow, never in a commit.** An ov
 ## Git Workflow
 
 - Default branch: `master`
-- Feature work: descriptive branches off `master`
+- **Feature work currently branches off, and PRs target, `feature/nuxt-4-migration` — not `master`.** That branch is the integration target until the migration lands; opening a PR against `master` would drag the migration diff in with it. Revert to `master` once it is merged.
 - Commit style: lowercase imperative with optional scope (`feat(search): add pagination`)
 - No pre-commit hooks
 

--- a/app/composables/useCast.ts
+++ b/app/composables/useCast.ts
@@ -117,7 +117,7 @@ export function useCast() {
     // video (set in castMedia) carries through to the active state as identity.
     if (playback.cast.kind !== 'idle' && remotePlayer.isMediaLoaded) {
       playback.setCastActive({
-        video: playback.cast.video,
+        videoKey: playback.cast.videoKey,
         position: remotePlayer.currentTime,
         duration: remotePlayer.duration,
         paused: remotePlayer.isPaused,
@@ -128,6 +128,42 @@ export function useCast() {
     // Only a drop after we were actually connected should idle the cast slice.
     if (!isConnecting.value && !remotePlayer.isConnected && playback.cast.kind !== 'idle') {
       playback.castIdle();
+    }
+  }
+
+  /**
+   * Re-adopt a session the SDK auto-rejoined after a page reload.
+   *
+   * The receiver keeps playing across the reload, but the store's cast slice
+   * starts idle — without this the CastBar never comes back and a dialog opened
+   * on the cast video would build a local player on top of the running cast.
+   * `castTargetKey` is the only thing that survives; title, device name,
+   * position and duration all refill from RemotePlayer events.
+   */
+  function restoreResumedSession() {
+    const videoKey = playback.castTargetKey;
+    if (!videoKey || playback.cast.kind !== 'idle') {
+      return;
+    }
+    const w = window as unknown as CastWindow;
+    const session = w.cast!.framework.CastContext.getInstance().getCurrentSession();
+    if (!session) {
+      return;
+    }
+
+    playback.setCastConnecting(videoKey, playback.lastCastPosition);
+    // The rejoined media is already loaded — there is no handoff seek pending
+    pendingStartTime = 0;
+
+    const mediaSession = session.getMediaSession();
+    const tracks = mediaSession?.media?.tracks ?? [];
+    hasCaptions.value = tracks.length > 0;
+    captionsEnabled.value = (mediaSession?.activeTrackIds ?? []).length > 0;
+
+    // Promote straight to active rather than waiting for the next event — a
+    // paused receiver emits none, which would leave the bar spinning
+    if (remotePlayer?.isConnected) {
+      syncRemotePlayer();
     }
   }
 
@@ -164,16 +200,24 @@ export function useCast() {
                   // Hand off at the live local position — the video kept
                   // playing while the picker was open
                   pendingStartTime = playback.localPositionOf(pendingCastVideo) || pendingStartTime;
-                  playback.setCastConnecting(pendingCastVideo, pendingStartTime);
+                  playback.setCastConnecting(
+                    pendingCastVideo.languageAgnosticNaturalKey,
+                    pendingStartTime,
+                  );
                 }
                 isConnecting.value = true;
                 break;
               }
               // Only now is getCurrentSession() guaranteed to return a session
               // that can accept a load request
-              case sessionState.SESSION_STARTED:
+              case sessionState.SESSION_STARTED: {
+                settleSessionWaiters(context.getCurrentSession());
+                break;
+              }
+              // A reload mid-cast rejoins the running session (ORIGIN_SCOPED)
               case sessionState.SESSION_RESUMED: {
                 settleSessionWaiters(context.getCurrentSession());
+                restoreResumedSession();
                 break;
               }
               case sessionState.SESSION_START_FAILED:
@@ -188,6 +232,11 @@ export function useCast() {
           },
         );
         isAvailable.value = true;
+        // Auto-join can finish before Vue mounts and calls initCast, in which
+        // case SESSION_RESUMED already fired with no listener attached
+        if (context.getCurrentSession()) {
+          restoreResumedSession();
+        }
       }
       catch {
         // Cast API present but configuration failed
@@ -298,7 +347,7 @@ export function useCast() {
         // Already casting — no device picker opens, so enter the connecting
         // state now and load the new media into the running session.
         if (video) {
-          playback.setCastConnecting(video, pendingStartTime);
+          playback.setCastConnecting(video.languageAgnosticNaturalKey, pendingStartTime);
         }
         isConnecting.value = true;
       }

--- a/app/stores/playback.ts
+++ b/app/stores/playback.ts
@@ -16,6 +16,10 @@ export const usePlaybackStore = defineStore('playback', () => {
   // Last known cast position, retained across `castIdle` so the local player
   // can resume there on the cast → local handoff (disconnect while open)
   const lastCastPosition = ref(0);
+  // The only persisted field: which video the running cast session is playing.
+  // The SDK rejoins the session after a reload but the `cast` slice starts idle,
+  // so this breadcrumb is what lets `useCast` restore it (see the persist block)
+  const castTargetKey = ref<string | null>(null);
 
   function keyOf(video: Video) {
     return video.languageAgnosticNaturalKey;
@@ -25,12 +29,13 @@ export const usePlaybackStore = defineStore('playback', () => {
   // Seed lastCastPosition with the local handoff position so a cancelled or
   // failed cast (e.g. the device picker dismissed without a selection) restores
   // the local player to where it was, not to 0
-  function setCastConnecting(video: Video, startPosition = 0) {
-    cast.value = { kind: 'connecting', video };
+  function setCastConnecting(videoKey: string, startPosition = 0) {
+    cast.value = { kind: 'connecting', videoKey };
     lastCastPosition.value = startPosition;
+    castTargetKey.value = videoKey;
   }
   function setCastActive(patch: {
-    video: Video;
+    videoKey: string;
     position: number;
     duration: number;
     paused: boolean;
@@ -42,6 +47,7 @@ export const usePlaybackStore = defineStore('playback', () => {
   }
   function castIdle() {
     cast.value = { kind: 'idle' };
+    castTargetKey.value = null;
   }
 
   // --- local slice (driven by usePlyrPlayer) ---
@@ -67,13 +73,13 @@ export const usePlaybackStore = defineStore('playback', () => {
       return false;
     }
     return (cast.value.kind === 'connecting' || cast.value.kind === 'active')
-      && keyOf(cast.value.video) === keyOf(video);
+      && cast.value.videoKey === keyOf(video);
   }
   function isCastingVideo(video: Video | null): boolean {
     if (!video) {
       return false;
     }
-    return cast.value.kind === 'active' && keyOf(cast.value.video) === keyOf(video);
+    return cast.value.kind === 'active' && cast.value.videoKey === keyOf(video);
   }
   function localPositionOf(video: Video | null): number {
     if (video && local.value.kind === 'ready' && keyOf(local.value.video) === keyOf(video)) {
@@ -93,6 +99,7 @@ export const usePlaybackStore = defineStore('playback', () => {
     cast,
     local,
     lastCastPosition,
+    castTargetKey,
     setCastConnecting,
     setCastActive,
     castIdle,
@@ -105,4 +112,12 @@ export const usePlaybackStore = defineStore('playback', () => {
     localPositionOf,
     positionFor,
   };
+}, {
+  persist: {
+    // sessionStorage, not the plugin's cookie default: the cast target is
+    // per-tab session state and has no business riding on every request.
+    // Deliberately separate from the language store's pinned 'app' cookie.
+    storage: piniaPluginPersistedstate.sessionStorage(),
+    pick: ['castTargetKey'],
+  },
 });

--- a/app/types/cast.ts
+++ b/app/types/cast.ts
@@ -58,6 +58,10 @@ export interface CastSession {
 
 export interface MediaSession {
   editTracksInfo: (request: object, onSuccess: () => void, onError: () => void) => void;
+  // Read when re-adopting a session the SDK rejoined after a reload — the
+  // caption state is not otherwise recoverable
+  activeTrackIds?: number[];
+  media?: { tracks?: MediaTrack[] };
 }
 
 export interface MediaInfo {

--- a/app/types/playback.ts
+++ b/app/types/playback.ts
@@ -1,17 +1,21 @@
 import type { Video } from '~/types';
 
 /**
- * Per-media playback session state for each transport. The `Video` is carried
- * in every non-idle state so a consumer can tell *which* video a transport is
- * playing (identity) without a separate key. Device/config state (volume,
+ * Per-media playback session state for each transport, carrying enough identity
+ * to tell *which* video a transport is playing. Device/config state (volume,
  * device name, captions, seek/pause capability) is NOT here — it lives as refs
  * in `useCast`, since it is not per-media.
+ *
+ * The cast slice holds only the `languageAgnosticNaturalKey`, not the `Video`:
+ * a cast session survives a page reload (ORIGIN_SCOPED auto-join) but a `Video`
+ * object does not, so the identity has to be something restorable from storage.
+ * The local slice is dialog-scoped and always has the real object.
  */
 
 export type CastState
   = | { kind: 'idle' }
-    | { kind: 'connecting'; video: Video }
-    | { kind: 'active'; video: Video; position: number; duration: number; paused: boolean };
+    | { kind: 'connecting'; videoKey: string }
+    | { kind: 'active'; videoKey: string; position: number; duration: number; paused: boolean };
 
 export type LocalState
   = | { kind: 'idle' }

--- a/test/nuxt/composables/useCast.test.ts
+++ b/test/nuxt/composables/useCast.test.ts
@@ -1,7 +1,8 @@
-import type { CastSession, CastWindow } from '~/types/cast';
+import type { CastSession, CastWindow, RemotePlayer } from '~/types/cast';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCast } from '~/composables/useCast';
+import { usePlaybackStore } from '~/stores/playback';
 
 /**
  * Fake Cast SDK. The behaviour under test is the session race: the SDK's
@@ -23,6 +24,9 @@ const session: CastSession = { loadMedia, getMediaSession: () => null };
 const sdk = {
   handlers: [] as ((event: { sessionState: string }) => void)[],
   currentSession: null as CastSession | null,
+  // The live RemotePlayer the composable holds, so tests can drive it
+  remotePlayer: null as RemotePlayer | null,
+  syncRemotePlayer: () => {},
   requestSession: vi.fn(async (): Promise<string | null | undefined> => null),
   emit(sessionState: string) {
     this.handlers.forEach(handler => handler({ sessionState }));
@@ -60,9 +64,15 @@ function installSdk() {
         canPause = false;
         displayName = 'Living Room';
         title = '';
+        constructor() {
+          sdk.remotePlayer = this as unknown as RemotePlayer;
+        }
       },
       RemotePlayerController: class {
-        addEventListener() {}
+        addEventListener(_type: string, handler: () => void) {
+          sdk.syncRemotePlayer = handler;
+        }
+
         playOrPause() {}
         muteOrUnmute() {}
         setVolumeLevel() {}
@@ -170,5 +180,58 @@ describe('useCast — castMedia session handling', () => {
 
     await expect(cast()).resolves.toBe(false);
     expect(useCast().castError.value).toBe('receiver_unavailable');
+  });
+});
+
+describe('useCast — resuming a session after a reload', () => {
+  // What a reloaded page starts from: the persisted key, an idle cast slice
+  // and a RemotePlayer the SDK has already rejoined to the receiver
+  function seedResumedSession(videoKey: string | null) {
+    const playback = usePlaybackStore();
+    playback.castIdle();
+    playback.castTargetKey = videoKey;
+    sdk.currentSession = session;
+    Object.assign(sdk.remotePlayer!, {
+      isConnected: true,
+      isMediaLoaded: true,
+      isPaused: true,
+      currentTime: 42,
+      duration: 300,
+      title: 'Some video',
+    });
+    return playback;
+  }
+
+  it('re-adopts the running cast from the persisted key', () => {
+    const playback = seedResumedSession('vid-A');
+
+    sdk.emit(SessionState.SESSION_RESUMED);
+
+    expect(playback.cast).toMatchObject({
+      kind: 'active',
+      videoKey: 'vid-A',
+      position: 42,
+      duration: 300,
+      paused: true,
+    });
+    expect(useCast().castDeviceName.value).toBe('Living Room');
+  });
+
+  it('stays idle when there is no persisted key (e.g. a new tab)', () => {
+    const playback = seedResumedSession(null);
+
+    sdk.emit(SessionState.SESSION_RESUMED);
+
+    expect(playback.cast.kind).toBe('idle');
+  });
+
+  it('clears the persisted key when the session ends', () => {
+    const playback = seedResumedSession('vid-A');
+    sdk.emit(SessionState.SESSION_RESUMED);
+
+    sdk.emit(SessionState.SESSION_ENDED);
+
+    expect(playback.cast.kind).toBe('idle');
+    expect(playback.castTargetKey).toBeNull();
   });
 });

--- a/test/nuxt/stores/playback.test.ts
+++ b/test/nuxt/stores/playback.test.ts
@@ -5,6 +5,8 @@ import { makeVideo } from '../../fixtures';
 
 const A = makeVideo('vid-A');
 const B = makeVideo('vid-B');
+const keyA = A.languageAgnosticNaturalKey;
+const keyB = B.languageAgnosticNaturalKey;
 
 beforeEach(() => setActivePinia(createPinia()));
 
@@ -17,7 +19,7 @@ describe('playback store — cast slice', () => {
 
   it('treats a connecting video as a target but not yet casting', () => {
     const s = usePlaybackStore();
-    s.setCastConnecting(A);
+    s.setCastConnecting(keyA);
     expect(s.cast.kind).toBe('connecting');
     expect(s.isCastTarget(A)).toBe(true);
     expect(s.isCastingVideo(A)).toBe(false);
@@ -25,8 +27,8 @@ describe('playback store — cast slice', () => {
 
   it('casts only the matching video (identity — the regression)', () => {
     const s = usePlaybackStore();
-    s.setCastConnecting(A);
-    s.setCastActive({ video: A, position: 12, duration: 100, paused: false });
+    s.setCastConnecting(keyA);
+    s.setCastActive({ videoKey: keyA, position: 12, duration: 100, paused: false });
     expect(s.isCastingVideo(A)).toBe(true);
     expect(s.isCastTarget(B)).toBe(false);
     expect(s.isCastingVideo(B)).toBe(false);
@@ -35,9 +37,9 @@ describe('playback store — cast slice', () => {
 
   it('tracks position and retains lastCastPosition across castIdle (handoff source)', () => {
     const s = usePlaybackStore();
-    s.setCastActive({ video: A, position: 5, duration: 100, paused: false });
+    s.setCastActive({ videoKey: keyA, position: 5, duration: 100, paused: false });
     // syncRemotePlayer pushes a full snapshot on every RemotePlayer change
-    s.setCastActive({ video: A, position: 42, duration: 100, paused: false });
+    s.setCastActive({ videoKey: keyA, position: 42, duration: 100, paused: false });
     expect(s.lastCastPosition).toBe(42);
     s.castIdle();
     expect(s.cast.kind).toBe('idle');
@@ -46,10 +48,31 @@ describe('playback store — cast slice', () => {
 
   it('resets lastCastPosition when a new cast connects', () => {
     const s = usePlaybackStore();
-    s.setCastActive({ video: A, position: 30, duration: 100, paused: false });
+    s.setCastActive({ videoKey: keyA, position: 30, duration: 100, paused: false });
     s.castIdle();
-    s.setCastConnecting(B);
+    s.setCastConnecting(keyB);
     expect(s.lastCastPosition).toBe(0);
+  });
+
+  it('writes and clears castTargetKey — the breadcrumb that survives a reload', () => {
+    const s = usePlaybackStore();
+    expect(s.castTargetKey).toBeNull();
+    s.setCastConnecting(keyA);
+    expect(s.castTargetKey).toBe(keyA);
+    s.setCastActive({ videoKey: keyA, position: 12, duration: 100, paused: false });
+    expect(s.castTargetKey).toBe(keyA);
+    s.castIdle();
+    expect(s.castTargetKey).toBeNull();
+  });
+
+  it('restores identity from a bare key, without the Video object', () => {
+    const s = usePlaybackStore();
+    // What useCast can reconstruct after a reload: the key and nothing else
+    s.setCastConnecting(keyA);
+    s.setCastActive({ videoKey: keyA, position: 30, duration: 100, paused: true });
+    expect(s.isCastTarget(A)).toBe(true);
+    expect(s.isCastingVideo(A)).toBe(true);
+    expect(s.isCastTarget(B)).toBe(false);
   });
 
   it('goes idle for a video that is not the cast target', () => {
@@ -62,7 +85,7 @@ describe('playback store — cast slice', () => {
 describe('playback store — coexistence', () => {
   it('holds an active cast and a ready local player simultaneously', () => {
     const s = usePlaybackStore();
-    s.setCastActive({ video: A, position: 100, duration: 200, paused: false });
+    s.setCastActive({ videoKey: keyA, position: 100, duration: 200, paused: false });
     s.setLocalReady(B);
     s.updateLocal({ position: 7 });
 


### PR DESCRIPTION
ORIGIN_SCOPED auto-join rejoins the running session on reload, but the playback store's cast slice started idle and syncRemotePlayer only writes to a non-idle slice — so CastBar never came back, and reopening the video's deep link built a local player that played over the still-running cast.

The blocker was CastState carrying a whole Video, which cannot exist right after a reload. It was only ever used as an identity key, so the cast slice now holds a videoKey string and the store persists just that one field in sessionStorage. useCast re-adopts the session from it, both on SESSION_RESUMED and at the tail of configureCast, since auto-join can beat Vue's mount. Caption state is read back off getMediaSession().

The breadcrumb is per-tab: a new tab auto-joins but shows no CastBar.


Claude-Session: https://claude.ai/code/session_01C8Ma7P7Q75ddyrPTaf6JzV