### PR TITLE
fix(player): fall back when a video has no release in the chosen language

### DIFF
--- a/app/components/cast/CastButton.vue
+++ b/app/components/cast/CastButton.vue
@@ -6,8 +6,8 @@
           <v-btn
             class="mr-2"
             color="primary"
-            :disabled="!castAvailable"
-            :loading="!videoMedia || !subtitleMedia || isAwaitingDevice"
+            :disabled="!castAvailable || !videoMedia"
+            :loading="loading || isAwaitingDevice"
             prepend-icon="mdi-cast"
             variant="elevated"
             v-bind="{ ...menuProps, ...tooltipProps }"
@@ -37,7 +37,7 @@ import type { MediaFile, Video } from '~/types';
 
 const props = defineProps<{
   videoMedia: Video | null;
-  subtitleMedia: Video | null;
+  loading: boolean;
   subtitleUrl: string | null;
   /** Local playback position — the cast starts here (handoff) */
   startTime?: number;

--- a/app/components/common/LanguageSelect.vue
+++ b/app/components/common/LanguageSelect.vue
@@ -2,11 +2,12 @@
   <v-autocomplete
     v-model="model"
     density="compact"
-    hide-details
+    hide-details="auto"
     :item-title="languageLabel"
     item-value="locale"
     :items="items"
     :list-props="{ density: 'compact' }"
+    :messages="message ?? []"
     :prepend-icon="icon"
     variant="outlined"
   />
@@ -18,6 +19,8 @@ import type { Language } from '~/types';
 defineProps<{
   items: Language[];
   icon: string;
+  /** Shown under the field; `hide-details="auto"` keeps the slot collapsed without one */
+  message?: string;
 }>();
 
 const model = defineModel<string>({ required: true });

--- a/app/components/player/TranscriptButton.vue
+++ b/app/components/player/TranscriptButton.vue
@@ -3,7 +3,7 @@
     class="ml-2"
     :color="subtitleUrl ? 'primary' : undefined"
     :disabled="subtitleUrl === null"
-    :loading="!subtitleMedia"
+    :loading="loading"
     :prepend-icon="uiStore.transcriptPanel ? 'mdi-arrow-left' : 'mdi-script-text-outline'"
     :variant="uiStore.transcriptPanel ? 'outlined' : 'elevated'"
     @click="uiStore.setTranscriptPanel(!uiStore.transcriptPanel)"
@@ -13,10 +13,8 @@
 </template>
 
 <script setup lang="ts">
-import type { Video } from '~/types';
-
 defineProps<{
-  subtitleMedia: Video | null;
+  loading: boolean;
   subtitleUrl: string | null;
 }>();
 

--- a/app/components/player/VideoDialog.vue
+++ b/app/components/player/VideoDialog.vue
@@ -114,6 +114,7 @@
                 icon="mdi-subtitles"
                 :items="availableLanguages"
                 :loading="subtitleLoading"
+                :message="subtitleFallbackHint"
               />
             </v-col>
           </v-row>
@@ -121,8 +122,8 @@
 
         <v-card-actions>
           <CastButton
+            :loading="loading || subtitleLoading"
             :start-time="localStartTime"
-            :subtitle-media="subtitleMedia"
             :subtitle-url="subtitleUrl"
             :video-media="videoMedia"
           />
@@ -131,7 +132,7 @@
 
           <TranscriptButton
             v-if="!landscapeMobile"
-            :subtitle-media="subtitleMedia"
+            :loading="subtitleLoading"
             :subtitle-url="subtitleUrl"
           />
         </v-card-actions>
@@ -171,8 +172,17 @@ const { castDeviceName, seekTo: castSeekTo } = useCast();
 
 const playerEl = ref<HTMLVideoElement | null>(null);
 
-const { loading, subtitleLoading, videoMedia, subtitleMedia, captionUrl, subtitleUrl }
-  = useMediaItems(() => captureResume());
+const {
+  loading,
+  subtitleLoading,
+  videoMedia,
+  captionUrl,
+  subtitleUrl,
+  availableLanguages,
+  resolvedVideoLanguage,
+  resolvedSubtitleLanguage,
+  subtitleUnavailable,
+} = useMediaItems(() => captureResume());
 
 // The cast session is global (one device); the store's cast slice carries the
 // video being cast, so this dialog mirrors it only when that video is the one
@@ -199,8 +209,10 @@ const dialog = computed({
   set: v => uiStore.setVideoDialog(v),
 });
 
+// The pickers show the language resolved against this video, so the field
+// always has a matching item; an explicit pick still updates the preference
 const videoLanguage = computed({
-  get: () => languageStore.videoLanguageInfo.locale,
+  get: () => resolvedVideoLanguage.value.locale,
   set: (v: string) => {
     if (!v) {
       return;
@@ -210,7 +222,7 @@ const videoLanguage = computed({
 });
 
 const subtitleLanguage = computed({
-  get: () => languageStore.subtitleLanguageInfo.locale,
+  get: () => resolvedSubtitleLanguage.value.locale,
   set: (v: string) => {
     if (!v) {
       return;
@@ -219,18 +231,16 @@ const subtitleLanguage = computed({
   },
 });
 
+// Names the language that was asked for, since the picker now shows the fallback
+const subtitleFallbackHint = computed(() =>
+  subtitleUnavailable.value
+    ? `${languageStore.subtitleLanguageInfo.name} — ${languageStore.t('MsgNoContent')}`
+    : undefined,
+);
+
 const videoPoster = computed(
   () => (uiStore.selectedVideo ?? videoMedia.value)?.images.wss.lg,
 );
-
-const availableLanguages = computed(() => {
-  if (!uiStore.selectedVideo) {
-    return [];
-  }
-  return languageStore.languages.filter(l =>
-    uiStore.selectedVideo!.availableLanguages.includes(l.code),
-  );
-});
 
 const {
   loadPlayer,
@@ -239,7 +249,14 @@ const {
   resetResume,
   seekTo: playerSeekTo,
   destroy: destroyPlayer,
-} = usePlyrPlayer(playerEl, { videoMedia, captionUrl, subtitleUrl, poster: videoPoster });
+} = usePlyrPlayer(playerEl, {
+  videoMedia,
+  captionUrl,
+  subtitleUrl,
+  poster: videoPoster,
+  videoLanguage: resolvedVideoLanguage,
+  subtitleLanguage: resolvedSubtitleLanguage,
+});
 
 // Exclusive playback: destroy the local player when casting takes over
 // (the <video> is v-if'd out); rebuild it at the last cast position when the

--- a/app/composables/useMediaItems.ts
+++ b/app/composables/useMediaItems.ts
@@ -5,6 +5,13 @@ import type { Video } from '~/types';
  * (`videoMedia`) and the subtitle-language media (`subtitleMedia`), refetched
  * when the selected video or either language changes.
  *
+ * A video is only released in some languages (`Video.availableLanguages`), so
+ * the persisted language preferences are reconciled against that list per video
+ * — asking for one the video was never translated into returns `media: []`,
+ * which used to leave the media `null` forever and park the dialog in a
+ * permanent spinner. The store is never written to: the preference survives,
+ * the substitution is scoped to this video.
+ *
  * `onBeforeLanguageReload` runs before a language switch clears the media —
  * the player uses it to capture the playback position it should restore.
  */
@@ -16,6 +23,43 @@ export function useMediaItems(onBeforeLanguageReload?: () => void) {
   const subtitleLoading = ref(false);
   const videoMedia = ref<Video | null>(null);
   const subtitleMedia = ref<Video | null>(null);
+
+  // The languages this video actually exists in — both pickers' item list
+  const availableLanguages = computed(() => {
+    const video = uiStore.selectedVideo;
+    if (!video) {
+      return [];
+    }
+    return languageStore.languages.filter(l => video.availableLanguages.includes(l.code));
+  });
+
+  const availableCodes = computed(() => uiStore.selectedVideo?.availableLanguages);
+
+  const resolvedVideoLanguage = computed(() =>
+    resolveAvailableLanguage(
+      languageStore.videoLanguageInfo,
+      [
+        languageStore.siteLanguageInfo,
+        languageStore.findLanguageByLocale('en'),
+        availableLanguages.value[0],
+      ],
+      availableCodes.value,
+    ),
+  );
+
+  // Falls back to the audio language, which has itself already landed on
+  // something the video exists in, so this chain always ends somewhere real
+  const resolvedSubtitleLanguage = computed(() =>
+    resolveAvailableLanguage(
+      languageStore.subtitleLanguageInfo,
+      [resolvedVideoLanguage.value],
+      availableCodes.value,
+    ),
+  );
+
+  const subtitleUnavailable = computed(
+    () => languageStore.subtitleLanguageInfo.locale !== resolvedSubtitleLanguage.value.locale,
+  );
 
   const captionUrl = computed(() => {
     const found = videoMedia.value?.files.find(f => f?.subtitles?.url);
@@ -44,7 +88,7 @@ export function useMediaItems(onBeforeLanguageReload?: () => void) {
 
     if (needVideo) {
       requests.push(
-        fetchMediaItem(languageStore.videoLanguageInfo.code, lank).then(media => {
+        fetchMediaItem(resolvedVideoLanguage.value.code, lank).then(media => {
           if (media) {
             videoMedia.value = media;
           }
@@ -53,7 +97,7 @@ export function useMediaItems(onBeforeLanguageReload?: () => void) {
     }
     if (needSubtitle) {
       requests.push(
-        fetchMediaItem(languageStore.subtitleLanguageInfo.code, lank).then(media => {
+        fetchMediaItem(resolvedSubtitleLanguage.value.code, lank).then(media => {
           if (media) {
             subtitleMedia.value = media;
           }
@@ -76,10 +120,10 @@ export function useMediaItems(onBeforeLanguageReload?: () => void) {
       videoMedia.value = null;
       subtitleMedia.value = null;
       // Pre-fill from selectedVideo if language matches
-      if (languageStore.siteLanguageInfo.locale === languageStore.videoLanguageInfo.locale) {
+      if (languageStore.siteLanguageInfo.locale === resolvedVideoLanguage.value.locale) {
         videoMedia.value = video;
       }
-      if (languageStore.siteLanguageInfo.locale === languageStore.subtitleLanguageInfo.locale) {
+      if (languageStore.siteLanguageInfo.locale === resolvedSubtitleLanguage.value.locale) {
         subtitleMedia.value = video;
       }
       loadMediaItems();
@@ -106,5 +150,16 @@ export function useMediaItems(onBeforeLanguageReload?: () => void) {
     },
   );
 
-  return { loading, subtitleLoading, videoMedia, subtitleMedia, captionUrl, subtitleUrl };
+  return {
+    loading,
+    subtitleLoading,
+    videoMedia,
+    subtitleMedia,
+    captionUrl,
+    subtitleUrl,
+    availableLanguages,
+    resolvedVideoLanguage,
+    resolvedSubtitleLanguage,
+    subtitleUnavailable,
+  };
 }

--- a/app/composables/usePlyrPlayer.ts
+++ b/app/composables/usePlyrPlayer.ts
@@ -1,7 +1,7 @@
 import type Plyr from 'plyr';
 import type { Track } from 'plyr';
 import type { Ref } from 'vue';
-import type { Video } from '~/types';
+import type { Language, Video } from '~/types';
 import { useDisplay } from 'vuetify';
 
 // mdi script-text-outline — same icon as the transcript button
@@ -19,9 +19,12 @@ export function usePlyrPlayer(
     captionUrl: Ref<string | null>;
     subtitleUrl: Ref<string | null>;
     poster: Ref<string | undefined>;
+    // Resolved against the video, not the raw preference — the track labels and
+    // srclangs have to name the language the .vtt is actually in
+    videoLanguage: Ref<Language>;
+    subtitleLanguage: Ref<Language>;
   },
 ) {
-  const languageStore = useLanguageStore();
   const uiStore = useUiStore();
   const playback = usePlaybackStore();
   const { smAndDown } = useDisplay();
@@ -118,7 +121,7 @@ export function usePlyrPlayer(
   // and that stored value wins over config.captions.language on every setup,
   // so the selected subtitle language has to be re-asserted rather than assumed.
   function syncCaptionLanguage() {
-    const locale = languageStore.subtitleLanguageInfo.locale;
+    const locale = source.subtitleLanguage.value.locale;
     if (!player || !source.subtitleUrl.value) {
       return;
     }
@@ -184,8 +187,8 @@ export function usePlyrPlayer(
 
     const track = document.createElement('track');
     track.kind = 'subtitles';
-    track.label = languageLabel(languageStore.subtitleLanguageInfo);
-    track.srclang = languageStore.subtitleLanguageInfo.locale;
+    track.label = languageLabel(source.subtitleLanguage.value);
+    track.srclang = source.subtitleLanguage.value.locale;
     track.src = url;
 
     // Plyr only registers a track once its own addtrack handler has populated
@@ -236,16 +239,16 @@ export function usePlyrPlayer(
     if (source.captionUrl.value) {
       tracks.push({
         kind: 'captions',
-        label: languageLabel(languageStore.videoLanguageInfo),
-        srcLang: languageStore.videoLanguageInfo.locale,
+        label: languageLabel(source.videoLanguage.value),
+        srcLang: source.videoLanguage.value.locale,
         src: source.captionUrl.value,
       });
     }
     if (source.subtitleUrl.value) {
       tracks.push({
         kind: 'subtitles',
-        label: languageLabel(languageStore.subtitleLanguageInfo),
-        srcLang: languageStore.subtitleLanguageInfo.locale,
+        label: languageLabel(source.subtitleLanguage.value),
+        srcLang: source.subtitleLanguage.value.locale,
         src: source.subtitleUrl.value,
       });
     }
@@ -264,7 +267,7 @@ export function usePlyrPlayer(
           'captions', 'settings', 'pip', 'airplay', 'fullscreen',
         ],
         quality: { default: 1080, options: [1080, 720, 480, 360, 240] },
-        captions: { active: true, language: languageStore.subtitleLanguageInfo.locale, update: true },
+        captions: { active: true, language: source.subtitleLanguage.value.locale, update: true },
         // Few enough options that the settings menu can't soft-lock
         speed: { selected: 1, options: [0.75, 1, 1.25, 1.5] },
         // Fullscreen the whole row so the transcript panel stays visible (desktop)

--- a/app/config/uiStrings.ts
+++ b/app/config/uiStrings.ts
@@ -7,8 +7,8 @@ import type { Translations } from '~/types';
  *
  * `en` is the fallback of last resort and MUST stay complete: several keys here
  * (lnkSearch, btnDownload, hdgSubtitles, btnPlay, btnPlayWith(out)Subtitles,
- * lnkHome, searchResultsCountText, noSearchResultsText, refineSearchResultsText)
- * are also real jw.org translation keys, so they normally resolve from the
+ * lnkHome, searchResultsCountText, noSearchResultsText, refineSearchResultsText,
+ * MsgNoContent) are also real jw.org translation keys, so they normally resolve from the
  * fetched translations at runtime — but if that fetch fails, `en` is all that's
  * left. Every other locale block therefore only needs the strings jw.org does
  * NOT provide: the bespoke shell copy + the three search sort labels (taken
@@ -46,6 +46,7 @@ export const uiStrings: Record<string, Translations> = {
     btnPlay: 'Play',
     btnPlayWithSubtitles: 'Play with subtitles',
     btnPlayWithoutSubtitles: 'Play without subtitles',
+    MsgNoContent: 'This content is not available in the selected language.',
   },
   nl: {
     guide: 'Handleiding',

--- a/app/utils/mediaLanguage.ts
+++ b/app/utils/mediaLanguage.ts
@@ -1,0 +1,18 @@
+import type { Language } from '~/types';
+
+/**
+ * The preferred language, unless the video was never released in it — then the
+ * first fallback it was. `available` holds Watchtower codes
+ * (`Video.availableLanguages`); an empty or unknown list means "no
+ * information", so `preferred` wins unchanged.
+ */
+export function resolveAvailableLanguage(
+  preferred: Language,
+  fallbacks: (Language | undefined)[],
+  available: string[] | undefined,
+): Language {
+  if (!available?.length || available.includes(preferred.code)) {
+    return preferred;
+  }
+  return fallbacks.find(l => l && available.includes(l.code)) ?? preferred;
+}

--- a/test/nuxt/composables/useMediaItems.test.ts
+++ b/test/nuxt/composables/useMediaItems.test.ts
@@ -1,0 +1,115 @@
+import type { Language, Video } from '~/types';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMediaItems } from '~/composables/useMediaItems';
+import { useLanguageStore } from '~/stores/language';
+import { useUiStore } from '~/stores/ui';
+import { makeVideo } from '../../fixtures';
+
+/**
+ * The case under test: a video released in English but not in the user's
+ * persisted subtitle language. `/media-items/O/<lank>` answers `{ media: [] }`
+ * for those, which used to leave `subtitleMedia` null forever.
+ */
+
+const { fetchMediaItem } = vi.hoisted(() => ({ fetchMediaItem: vi.fn() }));
+vi.mock('~/utils/api', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/utils/api')>()),
+  fetchMediaItem,
+}));
+
+const languages: Language[] = [
+  { code: 'O', locale: 'nl', vernacular: 'Nederlands', name: 'Dutch' },
+  { code: 'E', locale: 'en', vernacular: 'English', name: 'English' },
+  { code: 'S', locale: 'es', vernacular: 'español', name: 'Spanish' },
+];
+
+function mediaItem(code: string, availableLanguages: string[] = []): Video {
+  return makeVideo('pub-test', {
+    naturalKey: `pub-test_${code}`,
+    availableLanguages,
+    files: [{ subtitles: { url: `https://cdn.test/${code}.vtt` } }],
+  } as unknown as Partial<Video>);
+}
+
+/** Site language `en` so the English catalog item is what the dialog opens with */
+function openVideo(availableLanguages: string[], subtitleLocale: string) {
+  const languageStore = useLanguageStore();
+  languageStore.setLanguages(languages);
+  languageStore.setSiteLanguage('en');
+  languageStore.setVideoLanguage('en');
+  languageStore.setSubtitleLanguage(subtitleLocale);
+
+  const media = useMediaItems();
+  useUiStore().openVideo(mediaItem('E', availableLanguages));
+  return media;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  fetchMediaItem.mockImplementation(async (code: string) =>
+    (code === 'O' ? undefined : mediaItem(code)),
+  );
+});
+
+afterEach(() => {
+  fetchMediaItem.mockReset();
+});
+
+describe('useMediaItems language resolution', () => {
+  it('keeps the preferred subtitle language when the video has it', async() => {
+    const media = openVideo(['E', 'O', 'S'], 'nl');
+    await vi.waitFor(() => expect(media.subtitleLoading.value).toBe(false));
+
+    expect(media.resolvedSubtitleLanguage.value.locale).toBe('nl');
+    expect(media.subtitleUnavailable.value).toBe(false);
+    expect(fetchMediaItem).toHaveBeenCalledWith('O', 'pub-test');
+  });
+
+  it('falls back to the audio language when the video has no such release', async() => {
+    const media = openVideo(['E', 'S'], 'nl');
+    await vi.waitFor(() => expect(media.subtitleLoading.value).toBe(false));
+
+    expect(media.resolvedSubtitleLanguage.value.locale).toBe('en');
+    expect(media.subtitleUnavailable.value).toBe(true);
+    // The doomed request is never made — the empty response is what used to
+    // leave subtitleMedia null and the buttons spinning
+    expect(fetchMediaItem).not.toHaveBeenCalledWith('O', 'pub-test');
+  });
+
+  it('leaves the persisted preference alone', async() => {
+    const media = openVideo(['E', 'S'], 'nl');
+    await vi.waitFor(() => expect(media.subtitleLoading.value).toBe(false));
+
+    expect(useLanguageStore().subtitleLanguage).toBe('nl');
+  });
+
+  it('resolves the subtitle url and clears loading on the fallback path', async() => {
+    const media = openVideo(['E', 'S'], 'nl');
+    await vi.waitFor(() => expect(media.subtitleLoading.value).toBe(false));
+
+    expect(media.subtitleMedia.value).not.toBeNull();
+    expect(media.subtitleUrl.value).toBe('https://cdn.test/E.vtt');
+    expect(media.loading.value).toBe(false);
+  });
+
+  it('falls back for the audio language too', async() => {
+    const languageStore = useLanguageStore();
+    languageStore.setLanguages(languages);
+    languageStore.setSiteLanguage('en');
+    languageStore.setVideoLanguage('nl');
+    languageStore.setSubtitleLanguage('nl');
+
+    const media = useMediaItems();
+    useUiStore().openVideo(mediaItem('E', ['E', 'S']));
+    await vi.waitFor(() => expect(media.loading.value).toBe(false));
+
+    expect(media.resolvedVideoLanguage.value.locale).toBe('en');
+    expect(media.videoMedia.value).not.toBeNull();
+  });
+
+  it('offers only the languages the video was released in', () => {
+    const media = openVideo(['E', 'S'], 'nl');
+    expect(media.availableLanguages.value.map(l => l.locale)).toEqual(['en', 'es']);
+  });
+});

--- a/test/unit/mediaLanguage.test.ts
+++ b/test/unit/mediaLanguage.test.ts
@@ -1,0 +1,34 @@
+import type { Language } from '~/types';
+import { describe, expect, it } from 'vitest';
+import { resolveAvailableLanguage } from '~/utils/mediaLanguage';
+
+const nl: Language = { code: 'O', locale: 'nl', vernacular: 'Nederlands', name: 'Dutch' };
+const en: Language = { code: 'E', locale: 'en', vernacular: 'English', name: 'English' };
+const es: Language = { code: 'S', locale: 'es', vernacular: 'español', name: 'Spanish' };
+
+describe('resolveAvailableLanguage', () => {
+  it('keeps the preferred language when the video is released in it', () => {
+    expect(resolveAvailableLanguage(nl, [en], ['E', 'O', 'S'])).toBe(nl);
+  });
+
+  it('falls back to the first available candidate when it is not', () => {
+    expect(resolveAvailableLanguage(nl, [es, en], ['E', 'S'])).toBe(es);
+  });
+
+  it('skips fallbacks the video is not released in either', () => {
+    expect(resolveAvailableLanguage(nl, [es, en], ['E'])).toBe(en);
+  });
+
+  it('ignores undefined fallbacks', () => {
+    expect(resolveAvailableLanguage(nl, [undefined, en], ['E'])).toBe(en);
+  });
+
+  it('keeps the preferred language when nothing is available', () => {
+    expect(resolveAvailableLanguage(nl, [es, en], ['ASL'])).toBe(nl);
+  });
+
+  it('treats a missing or empty list as no information', () => {
+    expect(resolveAvailableLanguage(nl, [en], undefined)).toBe(nl);
+    expect(resolveAvailableLanguage(nl, [en], [])).toBe(nl);
+  });
+});


### PR DESCRIPTION
Opening a video that exists in the audio language but **not** in the persisted subtitle language parked the player dialog in a permanent half-loading state: the subtitle picker rendered the raw locale `nl`, the cast button spun forever, and the transcript button was disabled *and* spinning.

Repro: English catalog + persisted `subtitleLanguage: 'nl'` + `pub-jwbvod26_29_VIDEO`, which is released in English but not Dutch.

## Root cause

Two symptoms, one trigger.

`/media-items/O/<lank>` answers `{ "media": [] }` for a language a video was never translated into, so `fetchMediaItem` returns `undefined` and the `if (media)` guard in `useMediaItems` left `subtitleMedia` `null` for good — while `subtitleLoading` flipped `false` anyway. `null` meant both "not fetched yet" and "there is nothing to fetch", and both buttons read it as the former (`:loading="!subtitleMedia"`).

The raw `nl` was separate: `VideoDialog` already filtered both pickers to the video's `availableLanguages`, which excludes `O`, so the model value matched no item and Vuetify fell through to rendering the raw string.

The same hole existed on the **audio** side and was worse — a `null` `videoMedia` leaves `v-if="loading || !videoMedia"` spinning with no player at all.

## Approach

`Video.availableLanguages` is already on every catalog item (`VideoDialog` consumed it for the picker), but nothing reconciled it with the store — so the app could always tell *before fetching* that a language would come back empty. New pure util `resolveAvailableLanguage` (`app/utils/mediaLanguage.ts`) does that reconciliation, and `useMediaItems` now owns both the picker's item list and the resolved languages. The doomed request is never made.

**The store is untouched.** The preference survives to the next video, and an explicit pick still writes it — one English-only video no longer wipes a Dutch subtitle preference.

Where the preferred subtitle language is unavailable the picker shows the fallback and names the missing language underneath, via jw.org's own **`MsgNoContent`** key — a real translation key, so it arrives pre-translated in every language and needed only an `en` fallback entry, no per-locale translation work.

Two supporting changes:

- `!media` no longer stands in for "loading" on `CastButton`/`TranscriptButton` (both now take a `loading` prop and drop `subtitleMedia`), so even a failed fetch degrades to "no subtitles" instead of an eternal spinner — the bug *class* is closed, not just the reported trigger.
- `usePlyrPlayer` labels its `<track>` from the resolved language rather than the raw preference; otherwise Plyr's captions menu would read "Nederlands" over an English `.vtt`.

## Verification

Built the app, served it GitHub-Pages-style, seeded the `app` cookie with `subtitleLanguage: 'nl'`, and opened `/en/pub-jwbvod26_29_VIDEO` in a real browser against the live jw.org API:

| | before | after |
|---|---|---|
| subtitle picker | `nl` | `English` |
| hint | — | *Dutch — This content is not available in the selected language.* |
| cast button | spinning forever | resolved |
| transcript button | disabled + spinning | enabled, opens with English cues |
| `/media-items/O/…` | requested → `media: []` | never requested |

Preference survived: opening a Dutch-available video snaps back to "Dutch (Nederlands)", requests `O/…`, shows no hint, and the cookie still reads `subtitleLanguage: "nl"`.

`pnpm test` 76/76 · `pnpm lint` clean · `pnpm build` (with `typeCheck`) clean.
New specs: `test/unit/mediaLanguage.test.ts`, `test/nuxt/composables/useMediaItems.test.ts`.

## Notes

- **A released language with no `.vtt` is deliberately untouched** — French and ASL are both like that for this same video. `subtitleMedia` is non-null and `subtitleUrl` is `null`; that path is already correct and covered by `test/e2e/player.test.ts`, so no fallback fires and no hint shows. Say the word if that case should explain itself too.
- **`pnpm test:e2e` was not run** — it needs the browser to reach jw.org directly, which the sandbox proxy blocks for Chromium. Worth a local run before merge.
- A hard *network* failure on the audio-language fetch can still leave the player frame spinning (`VideoDialog.vue:24`). Pre-existing and a different trigger; fixing it means designing an error+retry state, so it is flagged rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xfc5PsVjTLyCUKYCNArLp

---
_Generated by [Claude Code](https://claude.ai/code/session_013xfc5PsVjTLyCUKYCNArLp)_